### PR TITLE
LOOP-6/LOOP-4 Implement TidepoolKit upload of initial data types

### DIFF
--- a/TidepoolKit Example/Base.lproj/Main.storyboard
+++ b/TidepoolKit Example/Base.lproj/Main.storyboard
@@ -80,7 +80,7 @@
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="51" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="&lt;userID&gt;" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IkC-fw-Mnq">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="51" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="&lt;userId&gt;" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IkC-fw-Mnq">
                                             <rect key="frame" x="80" y="87" width="275" height="17"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <nil key="textColor"/>
@@ -115,7 +115,7 @@
                                     <outlet property="authenticationTokenLabel" destination="fUM-Vk-uhD" id="4NB-od-Nrb"/>
                                     <outlet property="environmentLabel" destination="3z1-wF-2wm" id="2ia-3C-Lh7"/>
                                     <outlet property="stateLabel" destination="Zvw-uB-gtU" id="Fdl-WP-eya"/>
-                                    <outlet property="userIDLabel" destination="IkC-fw-Mnq" id="fg1-F1-DuG"/>
+                                    <outlet property="userIdLabel" destination="IkC-fw-Mnq" id="kpq-S8-cr1"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>

--- a/TidepoolKit Example/Support/Extensions/Bundle.swift
+++ b/TidepoolKit Example/Support/Extensions/Bundle.swift
@@ -1,0 +1,25 @@
+//
+//  Bundle.swift
+//  TidepoolKit Example
+//
+//  Created by Darin Krauss on 2/25/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+extension Bundle {
+    var semanticVersion: String? {
+        guard var semanticVersion = bundleShortVersionString else {
+            return nil
+        }
+        while semanticVersion.split(separator: ".").count < 3 {
+            semanticVersion += ".0"
+        }
+        return semanticVersion
+    }
+
+    var bundleShortVersionString: String? { string(forInfoDictionaryKey: "CFBundleShortVersionString") }
+
+    private func string(forInfoDictionaryKey key: String) -> String? { object(forInfoDictionaryKey: key) as? String }
+}

--- a/TidepoolKit Example/Support/Extensions/JSONEncoder.swift
+++ b/TidepoolKit Example/Support/Extensions/JSONEncoder.swift
@@ -1,0 +1,17 @@
+//
+//  JSONEncoder.swift
+//  TidepoolKit Example
+//
+//  Created by Darin Krauss on 3/3/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+public extension JSONEncoder {
+    static var pretty: JSONEncoder {
+        let encoder = JSONEncoder.tidepool
+        encoder.outputFormatting.insert(.prettyPrinted)
+        return encoder
+    }
+}

--- a/TidepoolKit Example/Support/Extensions/Sample.swift
+++ b/TidepoolKit Example/Support/Extensions/Sample.swift
@@ -1,0 +1,111 @@
+//
+//  Sample.swift
+//  TidepoolKit Example
+//
+//  Created by Darin Krauss on 3/4/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+import TidepoolKit
+
+struct Sample {
+    struct Datum {
+        static var data: [TDatum] {
+            return adorn(data: [
+                TCBGDatum(time: Date(),
+                          value: 123,
+                          units: .milligramsPerDeciliter),
+                TFoodDatum(time: Date(),
+                           name: "Darn Good Snack",
+                           amount: TFoodDatum.Amount(1.0, "cups"),
+                           brand: "Acme Foods",
+                           code: "1234567890",
+                           meal: .other,
+                           mealOther: "midnight snack",
+                           nutrition: foodNutrition,
+                           ingredients: [foodIngredient, foodIngredient])
+            ])
+        }
+
+        fileprivate static var foodIngredient: TFoodDatum.Ingredient {
+            return TFoodDatum.Ingredient(name: "Everything",
+                                         amount: TFoodDatum.Amount(1.0, "cups"),
+                                         brand: "Acme Foods",
+                                         code: "1234567890",
+                                         nutrition: foodNutrition,
+                                         ingredients: [TFoodDatum.Ingredient(name: "ether"),
+                                                       TFoodDatum.Ingredient(name: "air")])
+        }
+
+        fileprivate static var foodNutrition: TFoodDatum.Nutrition {
+            return TFoodDatum.Nutrition(carbohydrate: TFoodDatum.Nutrition.Carbohydrate(net: 30, sugars: 10, dietaryFiber: 5, total: 35),
+                                        fat: TFoodDatum.Nutrition.Fat(12),
+                                        protein: TFoodDatum.Nutrition.Protein(8),
+                                        energy: TFoodDatum.Nutrition.Energy(350, .kilocalories))
+        }
+
+        fileprivate static var location: TLocation {
+            return TLocation(name: "Home",
+                             gps: TLocation.GPS(latitude: TLocation.GPS.Latitude(37.773972),
+                                                longitude: TLocation.GPS.Longitude(-122.431297),
+                                                elevation: TLocation.GPS.Elevation(50, .meters),
+                                                floor: 31,
+                                                horizontalAccuracy: TLocation.GPS.Accuracy(10, .meters),
+                                                verticalAccuracy: TLocation.GPS.Accuracy(5, .meters),
+                                                origin: origin))
+        }
+
+        fileprivate static var origin: TOrigin {
+            return TOrigin(id: "3456789012",
+                           name: "Phone",
+                           version: "1.2.3",
+                           type: .device,
+                           time: Date(),
+                           payload: TDictionary(["one": 1]))
+        }
+
+        fileprivate static var annotations: [TDictionary] {
+            return [TDictionary(["alpha": 1, "beta": ["two"]]),
+                    TDictionary(["charlie": ["id": "three"]])]
+        }
+
+        fileprivate static var associations: [TAssociation] {
+            return [TAssociation(type: .datum, id: "12345678901234567890123456789012", reason: "Any reason will do"),
+                    TAssociation(type: .url, url: "https://tidepool.org")]
+        }
+
+        fileprivate static var notes: [String] {
+            return ["First Note", "Second Note"]
+        }
+
+        fileprivate static var payload: TDictionary {
+            return TDictionary(["foo": "bar"])
+        }
+
+        fileprivate static var tags: [String] {
+            return ["First Tag", "Second Tag"]
+        }
+
+        fileprivate static func adorn(data: [TDatum]) -> [TDatum] {
+            return data.map { adorn(datum: $0) }
+        }
+
+        fileprivate static func adorn(datum: TDatum) -> TDatum {
+            datum.annotations = annotations
+            datum.associations = associations
+            datum.clockDriftOffset = 123456
+            datum.conversionOffset = 2345
+            datum.deviceId = "my-device-id"
+            datum.deviceTime = "1999-12-31T12:34:45"
+            datum.location = location
+            datum.notes = notes
+            datum.origin = origin
+            datum.payload = payload
+            datum.tags = tags
+            datum.timezone = "America/Los_Angeles"
+            datum.timezoneOffset = -480
+            return datum
+        }
+    }
+}

--- a/TidepoolKit Example/Support/Extensions/UIAlertController.swift
+++ b/TidepoolKit Example/Support/Extensions/UIAlertController.swift
@@ -7,13 +7,20 @@
 //
 
 import UIKit
+import TidepoolKit
 
 extension UIAlertController {
     convenience init(error: Error, handler: (() -> Void)? = nil) {
+        TSharedLogging.error((error as CustomDebugStringConvertible).debugDescription)
         self.init(errorString: error.localizedDescription, handler: handler)
     }
 
-    convenience init(errorString: String, handler: (() -> Void)? = nil) {
+    convenience init(error: String, handler: (() -> Void)? = nil) {
+        TSharedLogging.error(error)
+        self.init(errorString: error, handler: handler)
+    }
+
+    private convenience init(errorString: String, handler: (() -> Void)? = nil) {
         self.init(title: NSLocalizedString("Error", comment: "The title of the error alert"), message: errorString, preferredStyle: .alert)
         addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "The title of the OK button in the error alert"), style: .default) { _ in handler?() })
     }

--- a/TidepoolKit Example/Support/Extensions/UserDefaults.swift
+++ b/TidepoolKit Example/Support/Extensions/UserDefaults.swift
@@ -13,17 +13,18 @@ extension UserDefaults {
     private enum Key: String {
         case environment = "org.tidepool.TidepoolKit-Example.environment"
         case session = "org.tidepool.TidepoolKit-Example.session"
+        case dataSetId = "org.tidepool.TidepoolKit-Example.dataSetId"
     }
 
     var environment: TEnvironment? {
         get {
-            guard let environmentRawValue = dictionary(forKey: Key.environment.rawValue) else {
+            guard let data = data(forKey: Key.environment.rawValue) else {
                 return nil
             }
-            return TEnvironment(rawValue: environmentRawValue)
+            return try? JSONDecoder.tidepool.decode(TEnvironment.self, from: data)
         }
         set {
-            set(newValue?.rawValue, forKey: Key.environment.rawValue)
+            set(try! JSONEncoder.tidepool.encode(newValue), forKey: Key.environment.rawValue)
         }
     }
 
@@ -31,13 +32,22 @@ extension UserDefaults {
     // for example purposes ONLY, use UserDefaults.
     var session: TSession? {
         get {
-            guard let sessionRawValue = dictionary(forKey: Key.session.rawValue) else {
+            guard let data = data(forKey: Key.session.rawValue) else {
                 return nil
             }
-            return TSession(rawValue: sessionRawValue)
+            return try? JSONDecoder.tidepool.decode(TSession.self, from: data)
         }
         set {
-            set(newValue?.rawValue, forKey: Key.session.rawValue)
+            set(try! JSONEncoder.tidepool.encode(newValue), forKey: Key.session.rawValue)
+        }
+    }
+
+    var dataSetId: String? {
+        get {
+            return string(forKey: Key.dataSetId.rawValue)
+        }
+        set {
+            set(newValue, forKey: Key.dataSetId.rawValue)
         }
     }
 }

--- a/TidepoolKit Example/Support/LoadingTableViewCell.swift
+++ b/TidepoolKit Example/Support/LoadingTableViewCell.swift
@@ -20,4 +20,8 @@ class LoadingTableViewCell: UITableViewCell {
             }
         }
     }
+
+    func stopLoading() {
+        self.isLoading = false
+    }
 }

--- a/TidepoolKit Example/Support/StatusTableViewCell.swift
+++ b/TidepoolKit Example/Support/StatusTableViewCell.swift
@@ -12,7 +12,7 @@ class StatusTableViewCell: UITableViewCell {
     @IBOutlet weak var stateLabel: UILabel!
     @IBOutlet weak var environmentLabel: UILabel!
     @IBOutlet weak var authenticationTokenLabel: UILabel!
-    @IBOutlet weak var userIDLabel: UILabel!
+    @IBOutlet weak var userIdLabel: UILabel!
 
     override public func prepareForReuse() {
         super.prepareForReuse()
@@ -20,7 +20,7 @@ class StatusTableViewCell: UITableViewCell {
         stateLabel?.text = nil
         environmentLabel?.text = nil
         authenticationTokenLabel?.text = nil
-        userIDLabel?.text = nil
+        userIdLabel?.text = nil
     }
 }
 

--- a/TidepoolKit Example/Support/TextViewController.swift
+++ b/TidepoolKit Example/Support/TextViewController.swift
@@ -1,0 +1,54 @@
+//
+//  TextViewController.swift
+//  TidepoolKit Example
+//
+//  Created by Darin Krauss on 2/21/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import UIKit
+import TidepoolKit
+
+class TextViewController: UIViewController {
+    private let text: String
+    private var textView: UITextView?
+
+    init(text: String, withTitle title: String? = nil) {
+        self.text = text
+
+        super.init(nibName: nil, bundle: nil)
+
+        self.title = title ?? NSLocalizedString("Text", comment: "The title of the text view controller")
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        super.loadView()
+
+        textView = UITextView()
+        view = textView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        textView?.contentInsetAdjustmentBehavior = .always
+        textView?.font = UIFontMetrics(forTextStyle: .body).scaledFont(for: UIFont.monospacedSystemFont(ofSize: 12, weight: .regular))
+        textView?.isEditable = false
+        textView?.text = text
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(share))
+    }
+
+    @objc func share() {
+        let activityItem = UTF8TextFileActivityItem(name: title!.replacingOccurrences(of: " ", with: "-"))
+        if let error = activityItem.write(text: text) {
+            present(UIAlertController(error: error), animated: true)
+        } else {
+            present(UIActivityViewController(activityItems: [activityItem], applicationActivities: nil), animated: true)
+        }
+    }
+}

--- a/TidepoolKit Example/Support/UTF8TextFileActivityItem.swift
+++ b/TidepoolKit Example/Support/UTF8TextFileActivityItem.swift
@@ -1,0 +1,60 @@
+//
+//  UTF8TextFileActivityItem.swift
+//  TidepoolKit Example
+//
+//  Created by Darin Krauss on 2/21/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class UTF8TextFileActivityItem: NSObject, UIActivityItemSource {
+    private let name: String
+    private let url: URL
+
+    init(name: String, withTimestamp timestamp: Date? = Date()) {
+        if let timestamp = timestamp {
+            self.name = "\(name)-\(Self.timestampFormatter.string(from: timestamp)).txt"
+        } else {
+            self.name = "\(name).txt"
+        }
+        self.url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(self.name, isDirectory: false)
+
+        super.init()
+    }
+
+    func write(text: String) -> Error? {
+        do {
+            try text.write(to: url, atomically: true, encoding: .utf8)
+            return nil
+        } catch let error {
+            return error
+        }
+    }
+
+    // MARK: - UIActivityItemSource
+
+    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        return url
+    }
+
+    func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+        return url
+    }
+
+    func activityViewController(_ activityViewController: UIActivityViewController, subjectForActivityType activityType: UIActivity.ActivityType?) -> String {
+        return name
+    }
+
+    func activityViewController(_ activityViewController: UIActivityViewController, dataTypeIdentifierForActivityType activityType: UIActivity.ActivityType?) -> String {
+        return "public.utf8-plain-text"
+    }
+
+    private static let timestampFormatter: DateFormatter = {
+        let timestampFormatter = DateFormatter()
+        timestampFormatter.dateFormat = "yyyy-MM-dd'T'HH-mm-ss"
+        timestampFormatter.timeZone = .current
+        return timestampFormatter
+    }()
+}

--- a/TidepoolKit.xcodeproj/project.pbxproj
+++ b/TidepoolKit.xcodeproj/project.pbxproj
@@ -8,7 +8,19 @@
 
 /* Begin PBXBuildFile section */
 		A903670523D939AE009BD8C5 /* TextButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A903670423D939AE009BD8C5 /* TextButtonTableViewCell.swift */; };
+		A9116ACD2405B7F300483021 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116ACC2405B7F300483021 /* Bundle.swift */; };
+		A9116ACF2405CC3300483021 /* LegacyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116ACE2405CC3300483021 /* LegacyResponse.swift */; };
+		A9116AD12405D81100483021 /* JSONDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116AD02405D81100483021 /* JSONDecoder.swift */; };
+		A9116AD32405D81B00483021 /* JSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116AD22405D81B00483021 /* JSONEncoder.swift */; };
+		A9116AD82406012600483021 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116AD62406012600483021 /* Date.swift */; };
+		A9116AD92406012600483021 /* TimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116AD72406012600483021 /* TimeInterval.swift */; };
+		A9116ADD24075D5A00483021 /* Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116ADC24075D5A00483021 /* Codable.swift */; };
+		A9116AE224083C1100483021 /* TDataSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116AE024083C1100483021 /* TDataSet.swift */; };
+		A9116AF32409D8C400483021 /* TDatum.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116AF12409D8C400483021 /* TDatum.swift */; };
+		A9116AF62409D8E000483021 /* DataResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116AF52409D8E000483021 /* DataResponse.swift */; };
+		A929A90D2411DDB300742B08 /* URLProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A929A90C2411DDB300742B08 /* URLProtocolMock.swift */; };
 		A92F62D223D7D0E3007B3CA6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A92F62D123D7D0E3007B3CA6 /* Assets.xcassets */; };
+		A93F59FE240D9C1800299E75 /* XCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93F59FD240D9C1800299E75 /* XCTest.swift */; };
 		A943535A23C932A10093CFA3 /* TidepoolKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A943535023C932A10093CFA3 /* TidepoolKit.framework */; };
 		A943536123C932A10093CFA3 /* TidepoolKit.h in Headers */ = {isa = PBXBuildFile; fileRef = A943535323C932A10093CFA3 /* TidepoolKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A943537823C932BF0093CFA3 /* TidepoolKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A943536F23C932BF0093CFA3 /* TidepoolKitUI.framework */; };
@@ -20,6 +32,8 @@
 		A943539723C932D20093CFA3 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A943539523C932D20093CFA3 /* LaunchScreen.storyboard */; };
 		A94D7D4323E242D60087A9C0 /* Locked.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94D7D4223E242D60087A9C0 /* Locked.swift */; };
 		A94D7D4523E243780087A9C0 /* UnfairLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94D7D4423E243780087A9C0 /* UnfairLock.swift */; };
+		A96633DE2409E99F007B68C1 /* TFoodDatum.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96633C22409E99F007B68C1 /* TFoodDatum.swift */; };
+		A96633E32409E99F007B68C1 /* TCBGDatum.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96633C82409E99F007B68C1 /* TCBGDatum.swift */; };
 		A973CD2323D68B6400C44032 /* TLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = A973CD2223D68B6400C44032 /* TLogging.swift */; };
 		A973CD2523D68E9D00C44032 /* LoginSignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A973CD2423D68E9D00C44032 /* LoginSignupViewController.swift */; };
 		A973CD2723D68FC300C44032 /* TAPI+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A973CD2623D68FC300C44032 /* TAPI+UI.swift */; };
@@ -30,6 +44,15 @@
 		A973CD3423D6916C00C44032 /* TidepoolKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A943536F23C932BF0093CFA3 /* TidepoolKitUI.framework */; };
 		A973CD3523D6916C00C44032 /* TidepoolKitUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A943536F23C932BF0093CFA3 /* TidepoolKitUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A973CD3B23D692D600C44032 /* LoginSignup.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A973CD3D23D692D600C44032 /* LoginSignup.storyboard */; };
+		A98780B8240A0D5E0007D5E1 /* TOriginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9878093240A0D5E0007D5E1 /* TOriginTests.swift */; };
+		A98780B9240A0D5E0007D5E1 /* TAsssociationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9878094240A0D5E0007D5E1 /* TAsssociationTests.swift */; };
+		A98780BA240A0D5E0007D5E1 /* TBloodGlucoseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9878095240A0D5E0007D5E1 /* TBloodGlucoseTests.swift */; };
+		A98780BB240A0D5E0007D5E1 /* TLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9878096240A0D5E0007D5E1 /* TLocationTests.swift */; };
+		A98780BD240A0D5E0007D5E1 /* TFoodDatumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9878099240A0D5E0007D5E1 /* TFoodDatumTests.swift */; };
+		A98780C6240A0D5E0007D5E1 /* TCBGDatumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98780A3240A0D5E0007D5E1 /* TCBGDatumTests.swift */; };
+		A98780CC240A0D5E0007D5E1 /* TDatumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98780A9240A0D5E0007D5E1 /* TDatumTests.swift */; };
+		A98780DB240A14E80007D5E1 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98780DA240A14E80007D5E1 /* Date.swift */; };
+		A98D55282410A50200EE62B5 /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98D55272410A50200EE62B5 /* Sample.swift */; };
 		A994916723FB288E00865738 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = A994916623FB288E00865738 /* Logging.swift */; };
 		A994916923FB4CF500865738 /* TEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A994916823FB4CF500865738 /* TEnvironment.swift */; };
 		A994916B23FB4D3200865738 /* TSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A994916A23FB4D3200865738 /* TSession.swift */; };
@@ -39,11 +62,27 @@
 		A994917A23FE15CE00865738 /* HTTPURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A994917923FE15CE00865738 /* HTTPURLResponse.swift */; };
 		A994917C23FE15E000865738 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A994917B23FE15E000865738 /* Bundle.swift */; };
 		A994918023FE1AD500865738 /* ProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A994917F23FE1AD500865738 /* ProcessInfo.swift */; };
+		A9BF06D0240EE47D005D5337 /* TDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BF06CF240EE47D005D5337 /* TDictionary.swift */; };
+		A9BF06D2240EEC87005D5337 /* TProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BF06D1240EEC87005D5337 /* TProfileTests.swift */; };
+		A9BF06D6240EF5BB005D5337 /* TDataSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BF06D5240EF5BB005D5337 /* TDataSetTests.swift */; };
+		A9BF06D8240F0A13005D5337 /* TEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BF06D7240F0A13005D5337 /* TEnvironmentTests.swift */; };
+		A9BF06DA240F0A20005D5337 /* TSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BF06D9240F0A20005D5337 /* TSessionTests.swift */; };
+		A9BF06E0240F2FF1005D5337 /* TAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BF06DF240F2FF1005D5337 /* TAPITests.swift */; };
+		A9BF06E4240F3051005D5337 /* JSONDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BF06E3240F3051005D5337 /* JSONDecoderTests.swift */; };
+		A9BF06E6240F305B005D5337 /* JSONEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BF06E5240F305B005D5337 /* JSONEncoderTests.swift */; };
+		A9BF06E8240F3557005D5337 /* JSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BF06E7240F3557005D5337 /* JSONEncoder.swift */; };
+		A9C57C2423FF3BFD00A5964D /* TBloodGlucose.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C57BF823FF3BFD00A5964D /* TBloodGlucose.swift */; };
+		A9C57C2823FF3BFD00A5964D /* TLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C57BFD23FF3BFD00A5964D /* TLocation.swift */; };
+		A9C57C2923FF3BFD00A5964D /* TAssociation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C57BFE23FF3BFD00A5964D /* TAssociation.swift */; };
+		A9C57C2A23FF3BFD00A5964D /* TOrigin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C57BFF23FF3BFD00A5964D /* TOrigin.swift */; };
 		A9C57C5023FF66A000A5964D /* LoginResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C57C4F23FF66A000A5964D /* LoginResponse.swift */; };
 		A9C57C5424005C3800A5964D /* LoadingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C57C5324005C3800A5964D /* LoadingTableViewCell.swift */; };
 		A9C57C562400628800A5964D /* IdentifiableClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C57C552400628800A5964D /* IdentifiableClass.swift */; };
+		A9C57C592400B76000A5964D /* TProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C57C582400B76000A5964D /* TProfile.swift */; };
+		A9C9D24F2400BFCC00D66F16 /* TextViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C9D24E2400BFCC00D66F16 /* TextViewController.swift */; };
 		A9C9D2522400CC4300D66F16 /* UIAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C9D2512400CC4300D66F16 /* UIAlertController.swift */; };
 		A9C9D2542400CC6500D66F16 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C9D2532400CC6500D66F16 /* UserDefaults.swift */; };
+		A9C9D2562400CD7A00D66F16 /* UTF8TextFileActivityItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C9D2552400CD7A00D66F16 /* UTF8TextFileActivityItem.swift */; };
 		A9EAB8E823DFC77E00874D2A /* DNS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EAB8E723DFC77E00874D2A /* DNS.swift */; };
 /* End PBXBuildFile section */
 
@@ -130,7 +169,19 @@
 
 /* Begin PBXFileReference section */
 		A903670423D939AE009BD8C5 /* TextButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextButtonTableViewCell.swift; sourceTree = "<group>"; };
+		A9116ACC2405B7F300483021 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
+		A9116ACE2405CC3300483021 /* LegacyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyResponse.swift; sourceTree = "<group>"; };
+		A9116AD02405D81100483021 /* JSONDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecoder.swift; sourceTree = "<group>"; };
+		A9116AD22405D81B00483021 /* JSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncoder.swift; sourceTree = "<group>"; };
+		A9116AD62406012600483021 /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
+		A9116AD72406012600483021 /* TimeInterval.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeInterval.swift; sourceTree = "<group>"; };
+		A9116ADC24075D5A00483021 /* Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Codable.swift; sourceTree = "<group>"; };
+		A9116AE024083C1100483021 /* TDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TDataSet.swift; sourceTree = "<group>"; };
+		A9116AF12409D8C400483021 /* TDatum.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TDatum.swift; sourceTree = "<group>"; };
+		A9116AF52409D8E000483021 /* DataResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataResponse.swift; sourceTree = "<group>"; };
+		A929A90C2411DDB300742B08 /* URLProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolMock.swift; sourceTree = "<group>"; };
 		A92F62D123D7D0E3007B3CA6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A93F59FD240D9C1800299E75 /* XCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTest.swift; sourceTree = "<group>"; };
 		A943535023C932A10093CFA3 /* TidepoolKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TidepoolKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A943535323C932A10093CFA3 /* TidepoolKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TidepoolKit.h; sourceTree = "<group>"; };
 		A943535423C932A10093CFA3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -150,11 +201,22 @@
 		A943539823C932D20093CFA3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A94D7D4223E242D60087A9C0 /* Locked.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locked.swift; sourceTree = "<group>"; };
 		A94D7D4423E243780087A9C0 /* UnfairLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnfairLock.swift; sourceTree = "<group>"; };
+		A96633C22409E99F007B68C1 /* TFoodDatum.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TFoodDatum.swift; sourceTree = "<group>"; };
+		A96633C82409E99F007B68C1 /* TCBGDatum.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TCBGDatum.swift; sourceTree = "<group>"; };
 		A973CD2223D68B6400C44032 /* TLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLogging.swift; sourceTree = "<group>"; };
 		A973CD2423D68E9D00C44032 /* LoginSignupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSignupViewController.swift; sourceTree = "<group>"; };
 		A973CD2623D68FC300C44032 /* TAPI+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TAPI+UI.swift"; sourceTree = "<group>"; };
 		A973CD2823D68FE000C44032 /* TAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAPI.swift; sourceTree = "<group>"; };
 		A973CD3C23D692D600C44032 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LoginSignup.storyboard; sourceTree = "<group>"; };
+		A9878093240A0D5E0007D5E1 /* TOriginTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TOriginTests.swift; sourceTree = "<group>"; };
+		A9878094240A0D5E0007D5E1 /* TAsssociationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TAsssociationTests.swift; sourceTree = "<group>"; };
+		A9878095240A0D5E0007D5E1 /* TBloodGlucoseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TBloodGlucoseTests.swift; sourceTree = "<group>"; };
+		A9878096240A0D5E0007D5E1 /* TLocationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TLocationTests.swift; sourceTree = "<group>"; };
+		A9878099240A0D5E0007D5E1 /* TFoodDatumTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TFoodDatumTests.swift; sourceTree = "<group>"; };
+		A98780A3240A0D5E0007D5E1 /* TCBGDatumTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TCBGDatumTests.swift; sourceTree = "<group>"; };
+		A98780A9240A0D5E0007D5E1 /* TDatumTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TDatumTests.swift; sourceTree = "<group>"; };
+		A98780DA240A14E80007D5E1 /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
+		A98D55272410A50200EE62B5 /* Sample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sample.swift; sourceTree = "<group>"; };
 		A994916623FB288E00865738 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		A994916823FB4CF500865738 /* TEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TEnvironment.swift; sourceTree = "<group>"; };
 		A994916A23FB4D3200865738 /* TSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TSession.swift; sourceTree = "<group>"; };
@@ -164,11 +226,27 @@
 		A994917923FE15CE00865738 /* HTTPURLResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPURLResponse.swift; sourceTree = "<group>"; };
 		A994917B23FE15E000865738 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		A994917F23FE1AD500865738 /* ProcessInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfo.swift; sourceTree = "<group>"; };
+		A9BF06CF240EE47D005D5337 /* TDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TDictionary.swift; sourceTree = "<group>"; };
+		A9BF06D1240EEC87005D5337 /* TProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TProfileTests.swift; sourceTree = "<group>"; };
+		A9BF06D5240EF5BB005D5337 /* TDataSetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TDataSetTests.swift; sourceTree = "<group>"; };
+		A9BF06D7240F0A13005D5337 /* TEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TEnvironmentTests.swift; sourceTree = "<group>"; };
+		A9BF06D9240F0A20005D5337 /* TSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TSessionTests.swift; sourceTree = "<group>"; };
+		A9BF06DF240F2FF1005D5337 /* TAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAPITests.swift; sourceTree = "<group>"; };
+		A9BF06E3240F3051005D5337 /* JSONDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecoderTests.swift; sourceTree = "<group>"; };
+		A9BF06E5240F305B005D5337 /* JSONEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncoderTests.swift; sourceTree = "<group>"; };
+		A9BF06E7240F3557005D5337 /* JSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncoder.swift; sourceTree = "<group>"; };
+		A9C57BF823FF3BFD00A5964D /* TBloodGlucose.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TBloodGlucose.swift; sourceTree = "<group>"; };
+		A9C57BFD23FF3BFD00A5964D /* TLocation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TLocation.swift; sourceTree = "<group>"; };
+		A9C57BFE23FF3BFD00A5964D /* TAssociation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TAssociation.swift; sourceTree = "<group>"; };
+		A9C57BFF23FF3BFD00A5964D /* TOrigin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TOrigin.swift; sourceTree = "<group>"; };
 		A9C57C4F23FF66A000A5964D /* LoginResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponse.swift; sourceTree = "<group>"; };
 		A9C57C5324005C3800A5964D /* LoadingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingTableViewCell.swift; sourceTree = "<group>"; };
 		A9C57C552400628800A5964D /* IdentifiableClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableClass.swift; sourceTree = "<group>"; };
+		A9C57C582400B76000A5964D /* TProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TProfile.swift; sourceTree = "<group>"; };
+		A9C9D24E2400BFCC00D66F16 /* TextViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewController.swift; sourceTree = "<group>"; };
 		A9C9D2512400CC4300D66F16 /* UIAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAlertController.swift; sourceTree = "<group>"; };
 		A9C9D2532400CC6500D66F16 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
+		A9C9D2552400CD7A00D66F16 /* UTF8TextFileActivityItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTF8TextFileActivityItem.swift; sourceTree = "<group>"; };
 		A9EAB8E723DFC77E00874D2A /* DNS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNS.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -216,6 +294,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A9116AE424083C4C00483021 /* Datum */ = {
+			isa = PBXGroup;
+			children = (
+				A96633C82409E99F007B68C1 /* TCBGDatum.swift */,
+				A9116AF12409D8C400483021 /* TDatum.swift */,
+				A96633C22409E99F007B68C1 /* TFoodDatum.swift */,
+			);
+			path = Datum;
+			sourceTree = "<group>";
+		};
 		A943534623C932A10093CFA3 = {
 			isa = PBXGroup;
 			children = (
@@ -251,7 +339,9 @@
 				A994916C23FB54D200865738 /* TError.swift */,
 				A973CD2223D68B6400C44032 /* TLogging.swift */,
 				A994916A23FB4D3200865738 /* TSession.swift */,
+				A9C57C2123FF3BFD00A5964D /* Extensions */,
 				A94D7D4623E246C40087A9C0 /* Internal */,
+				A9C57BF723FF3BFD00A5964D /* Model */,
 			);
 			path = TidepoolKit;
 			sourceTree = "<group>";
@@ -260,6 +350,12 @@
 			isa = PBXGroup;
 			children = (
 				A943536023C932A10093CFA3 /* Info.plist */,
+				A9BF06DF240F2FF1005D5337 /* TAPITests.swift */,
+				A9BF06D7240F0A13005D5337 /* TEnvironmentTests.swift */,
+				A9BF06D9240F0A20005D5337 /* TSessionTests.swift */,
+				A9BF06E2240F3041005D5337 /* Extensions */,
+				A9BF06E1240F3023005D5337 /* Internal */,
+				A9878092240A0D5E0007D5E1 /* Model */,
 			);
 			path = TidepoolKitTests;
 			sourceTree = "<group>";
@@ -317,6 +413,39 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		A9878092240A0D5E0007D5E1 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				A9878094240A0D5E0007D5E1 /* TAsssociationTests.swift */,
+				A9878095240A0D5E0007D5E1 /* TBloodGlucoseTests.swift */,
+				A9BF06D5240EF5BB005D5337 /* TDataSetTests.swift */,
+				A9878096240A0D5E0007D5E1 /* TLocationTests.swift */,
+				A9878093240A0D5E0007D5E1 /* TOriginTests.swift */,
+				A9BF06D1240EEC87005D5337 /* TProfileTests.swift */,
+				A9878097240A0D5E0007D5E1 /* Datum */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		A9878097240A0D5E0007D5E1 /* Datum */ = {
+			isa = PBXGroup;
+			children = (
+				A98780A3240A0D5E0007D5E1 /* TCBGDatumTests.swift */,
+				A98780A9240A0D5E0007D5E1 /* TDatumTests.swift */,
+				A9878099240A0D5E0007D5E1 /* TFoodDatumTests.swift */,
+			);
+			path = Datum;
+			sourceTree = "<group>";
+		};
+		A98780D9240A14E80007D5E1 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				A98780DA240A14E80007D5E1 /* Date.swift */,
+				A93F59FD240D9C1800299E75 /* XCTest.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		A994917023FB61E400865738 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
@@ -331,9 +460,54 @@
 			isa = PBXGroup;
 			children = (
 				A994917B23FE15E000865738 /* Bundle.swift */,
+				A9116ADC24075D5A00483021 /* Codable.swift */,
+				A9116AD62406012600483021 /* Date.swift */,
 				A994917323FB88A300865738 /* DNS+TEnvironment.swift */,
 				A994917923FE15CE00865738 /* HTTPURLResponse.swift */,
 				A994917F23FE1AD500865738 /* ProcessInfo.swift */,
+				A9116AD72406012600483021 /* TimeInterval.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		A9BF06E1240F3023005D5337 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				A929A90C2411DDB300742B08 /* URLProtocolMock.swift */,
+				A98780D9240A14E80007D5E1 /* Extensions */,
+			);
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		A9BF06E2240F3041005D5337 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				A9BF06E3240F3051005D5337 /* JSONDecoderTests.swift */,
+				A9BF06E5240F305B005D5337 /* JSONEncoderTests.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		A9C57BF723FF3BFD00A5964D /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				A9C57BFE23FF3BFD00A5964D /* TAssociation.swift */,
+				A9C57BF823FF3BFD00A5964D /* TBloodGlucose.swift */,
+				A9116AE024083C1100483021 /* TDataSet.swift */,
+				A9BF06CF240EE47D005D5337 /* TDictionary.swift */,
+				A9C57BFD23FF3BFD00A5964D /* TLocation.swift */,
+				A9C57BFF23FF3BFD00A5964D /* TOrigin.swift */,
+				A9C57C582400B76000A5964D /* TProfile.swift */,
+				A9116AE424083C4C00483021 /* Datum */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		A9C57C2123FF3BFD00A5964D /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				A9116AD02405D81100483021 /* JSONDecoder.swift */,
+				A9116AD22405D81B00483021 /* JSONEncoder.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -341,6 +515,8 @@
 		A9C57C4E23FF668300A5964D /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				A9116AF52409D8E000483021 /* DataResponse.swift */,
+				A9116ACE2405CC3300483021 /* LegacyResponse.swift */,
 				A9C57C4F23FF66A000A5964D /* LoginResponse.swift */,
 			);
 			path = Responses;
@@ -353,6 +529,8 @@
 				A9C57C5324005C3800A5964D /* LoadingTableViewCell.swift */,
 				A994917123FB6C1100865738 /* StatusTableViewCell.swift */,
 				A903670423D939AE009BD8C5 /* TextButtonTableViewCell.swift */,
+				A9C9D24E2400BFCC00D66F16 /* TextViewController.swift */,
+				A9C9D2552400CD7A00D66F16 /* UTF8TextFileActivityItem.swift */,
 				A9C9D2502400CC1600D66F16 /* Extensions */,
 			);
 			path = Support;
@@ -361,6 +539,9 @@
 		A9C9D2502400CC1600D66F16 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				A9116ACC2405B7F300483021 /* Bundle.swift */,
+				A9BF06E7240F3557005D5337 /* JSONEncoder.swift */,
+				A98D55272410A50200EE62B5 /* Sample.swift */,
 				A9C9D2512400CC4300D66F16 /* UIAlertController.swift */,
 				A9C9D2532400CC6500D66F16 /* UserDefaults.swift */,
 			);
@@ -585,19 +766,36 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A9116AE224083C1100483021 /* TDataSet.swift in Sources */,
 				A9EAB8E823DFC77E00874D2A /* DNS.swift in Sources */,
+				A9116AF62409D8E000483021 /* DataResponse.swift in Sources */,
+				A9C57C2423FF3BFD00A5964D /* TBloodGlucose.swift in Sources */,
 				A9C57C5023FF66A000A5964D /* LoginResponse.swift in Sources */,
+				A9116AF32409D8C400483021 /* TDatum.swift in Sources */,
 				A994918023FE1AD500865738 /* ProcessInfo.swift in Sources */,
 				A994917C23FE15E000865738 /* Bundle.swift in Sources */,
+				A96633DE2409E99F007B68C1 /* TFoodDatum.swift in Sources */,
 				A994916923FB4CF500865738 /* TEnvironment.swift in Sources */,
+				A9C57C2823FF3BFD00A5964D /* TLocation.swift in Sources */,
 				A994917A23FE15CE00865738 /* HTTPURLResponse.swift in Sources */,
+				A9116ADD24075D5A00483021 /* Codable.swift in Sources */,
+				A96633E32409E99F007B68C1 /* TCBGDatum.swift in Sources */,
 				A994917423FB88A300865738 /* DNS+TEnvironment.swift in Sources */,
+				A9116AD92406012600483021 /* TimeInterval.swift in Sources */,
 				A94D7D4323E242D60087A9C0 /* Locked.swift in Sources */,
 				A973CD2323D68B6400C44032 /* TLogging.swift in Sources */,
+				A9116AD82406012600483021 /* Date.swift in Sources */,
 				A994916B23FB4D3200865738 /* TSession.swift in Sources */,
+				A9C57C2923FF3BFD00A5964D /* TAssociation.swift in Sources */,
+				A9BF06D0240EE47D005D5337 /* TDictionary.swift in Sources */,
+				A9116AD12405D81100483021 /* JSONDecoder.swift in Sources */,
+				A9116AD32405D81B00483021 /* JSONEncoder.swift in Sources */,
 				A994916D23FB54D200865738 /* TError.swift in Sources */,
+				A9116ACF2405CC3300483021 /* LegacyResponse.swift in Sources */,
+				A9C57C2A23FF3BFD00A5964D /* TOrigin.swift in Sources */,
 				A94D7D4523E243780087A9C0 /* UnfairLock.swift in Sources */,
 				A973CD2923D68FE000C44032 /* TAPI.swift in Sources */,
+				A9C57C592400B76000A5964D /* TProfile.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -605,6 +803,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A9BF06E0240F2FF1005D5337 /* TAPITests.swift in Sources */,
+				A9BF06E6240F305B005D5337 /* JSONEncoderTests.swift in Sources */,
+				A98780CC240A0D5E0007D5E1 /* TDatumTests.swift in Sources */,
+				A98780C6240A0D5E0007D5E1 /* TCBGDatumTests.swift in Sources */,
+				A9BF06D8240F0A13005D5337 /* TEnvironmentTests.swift in Sources */,
+				A9BF06D6240EF5BB005D5337 /* TDataSetTests.swift in Sources */,
+				A98780BA240A0D5E0007D5E1 /* TBloodGlucoseTests.swift in Sources */,
+				A9BF06E4240F3051005D5337 /* JSONDecoderTests.swift in Sources */,
+				A93F59FE240D9C1800299E75 /* XCTest.swift in Sources */,
+				A98780B9240A0D5E0007D5E1 /* TAsssociationTests.swift in Sources */,
+				A929A90D2411DDB300742B08 /* URLProtocolMock.swift in Sources */,
+				A98780B8240A0D5E0007D5E1 /* TOriginTests.swift in Sources */,
+				A98780DB240A14E80007D5E1 /* Date.swift in Sources */,
+				A9BF06D2240EEC87005D5337 /* TProfileTests.swift in Sources */,
+				A98780BD240A0D5E0007D5E1 /* TFoodDatumTests.swift in Sources */,
+				A98780BB240A0D5E0007D5E1 /* TLocationTests.swift in Sources */,
+				A9BF06DA240F0A20005D5337 /* TSessionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -629,12 +844,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				A903670523D939AE009BD8C5 /* TextButtonTableViewCell.swift in Sources */,
+				A9116ACD2405B7F300483021 /* Bundle.swift in Sources */,
+				A9BF06E8240F3557005D5337 /* JSONEncoder.swift in Sources */,
+				A98D55282410A50200EE62B5 /* Sample.swift in Sources */,
 				A9C9D2522400CC4300D66F16 /* UIAlertController.swift in Sources */,
 				A9C57C562400628800A5964D /* IdentifiableClass.swift in Sources */,
 				A994917223FB6C1100865738 /* StatusTableViewCell.swift in Sources */,
 				A9C57C5424005C3800A5964D /* LoadingTableViewCell.swift in Sources */,
 				A943538F23C932D10093CFA3 /* RootTableViewController.swift in Sources */,
+				A9C9D2562400CD7A00D66F16 /* UTF8TextFileActivityItem.swift in Sources */,
 				A9C9D2542400CC6500D66F16 /* UserDefaults.swift in Sources */,
+				A9C9D24F2400BFCC00D66F16 /* TextViewController.swift in Sources */,
 				A943538D23C932D10093CFA3 /* AppDelegate.swift in Sources */,
 				A994916723FB288E00865738 /* Logging.swift in Sources */,
 			);
@@ -1062,6 +1282,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = 75U4X84TEG;
 				INFOPLIST_FILE = "TidepoolKit Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1076,6 +1297,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = 75U4X84TEG;
 				INFOPLIST_FILE = "TidepoolKit Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/TidepoolKit/Extensions/JSONDecoder.swift
+++ b/TidepoolKit/Extensions/JSONDecoder.swift
@@ -1,0 +1,30 @@
+//
+//  JSONDecoder.swift
+//  TidepoolKit
+//
+//  Created by Darin Krauss on 2/25/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+public extension JSONDecoder {
+    static var tidepool: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .tidepool
+        return decoder
+    }
+}
+
+public extension JSONDecoder.DateDecodingStrategy {
+    static var tidepool: JSONDecoder.DateDecodingStrategy {
+        return .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let string = try container.decode(String.self)
+            guard let date = Date(timeString: string) else {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Expected date string '\(string)' to be Tidepool ISO8601-formatted.")
+            }
+            return date
+        }
+    }
+}

--- a/TidepoolKit/Extensions/JSONEncoder.swift
+++ b/TidepoolKit/Extensions/JSONEncoder.swift
@@ -1,0 +1,27 @@
+//
+//  JSONEncoder.swift
+//  TidepoolKit
+//
+//  Created by Darin Krauss on 2/25/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+public extension JSONEncoder {
+    static var tidepool: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .tidepool
+        return encoder
+    }
+}
+
+public extension JSONEncoder.DateEncodingStrategy {
+    static var tidepool: JSONEncoder.DateEncodingStrategy {
+        return .custom { (date, encoder) in
+            var encoder = encoder.singleValueContainer()
+            try encoder.encode(date.timeString)
+        }
+    }
+}

--- a/TidepoolKit/Internal/Extensions/Codable.swift
+++ b/TidepoolKit/Internal/Extensions/Codable.swift
@@ -1,0 +1,222 @@
+//
+//  Codable.swift
+//  TidepoolKit
+//
+//  Created by Darin Krauss on 2/26/20.
+//
+
+// Original: https://gist.github.com/sukov/d3834c0e7b72e4f7575f753b352f6ddd
+
+import Foundation
+
+struct JSONCodingKeys: CodingKey {
+    var stringValue: String
+
+    init(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    var intValue: Int?
+
+    init?(intValue: Int) {
+        self.init(stringValue: "\(intValue)")
+        self.intValue = intValue
+    }
+}
+
+extension KeyedDecodingContainer {
+    func decode(_ type: [[String: Any]].Type, forKey key: K) throws -> [[String: Any]] {
+        var container = try nestedUnkeyedContainer(forKey: key)
+        return try container.decode(type)
+    }
+
+    func decode(_ type: [String: Any].Type, forKey key: K) throws -> [String: Any] {
+        let container = try nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
+        return try container.decode(type)
+    }
+
+    func decode(_ type: [Any].Type, forKey key: K) throws -> [Any] {
+        var container = try nestedUnkeyedContainer(forKey: key)
+        return try container.decode(type)
+    }
+
+    func decodeIfPresent(_ type: [[String: Any]].Type, forKey key: K) throws -> [[String: Any]]? {
+        guard contains(key) else { return nil }
+
+        return try decode(type, forKey: key)
+    }
+
+    func decodeIfPresent(_ type: [String: Any].Type, forKey key: K) throws -> [String: Any]? {
+        guard contains(key) else { return nil }
+
+        return try decode(type, forKey: key)
+    }
+
+    func decodeIfPresent(_ type: [Any].Type, forKey key: K) throws -> [Any]? {
+        guard contains(key) else { return nil }
+
+        return try decode(type, forKey: key)
+    }
+
+    func decode(_ type: [String: Any].Type) throws -> [String: Any] {
+        var dictionary = [String: Any]()
+
+        for key in allKeys {
+            if let boolValue = try? decode(Bool.self, forKey: key) {
+                dictionary[key.stringValue] = boolValue
+            } else if let intValue = try? decode(Int.self, forKey: key) {
+                dictionary[key.stringValue] = intValue
+            } else if let stringValue = try? decode(String.self, forKey: key) {
+                dictionary[key.stringValue] = stringValue
+            } else if let doubleValue = try? decode(Double.self, forKey: key) {
+                dictionary[key.stringValue] = doubleValue
+            } else if let nestedDictionary = try? decode([String: Any].self, forKey: key) {
+                dictionary[key.stringValue] = nestedDictionary
+            } else if let nestedArray = try? decode([Any].self, forKey: key) {
+                dictionary[key.stringValue] = nestedArray
+            } else if let isValueNil = try? decodeNil(forKey: key), isValueNil == true {
+                dictionary[key.stringValue] = nil
+            } else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath + [key], debugDescription: "Unable to decode value"))
+            }
+        }
+        return dictionary
+    }
+}
+
+extension UnkeyedDecodingContainer {
+    mutating func decode(_ type: [[String: Any]].Type) throws -> [[String: Any]] {
+        var array: [[String: Any]] = []
+
+        while isAtEnd == false {
+            if let dictionary = try? decode([String: Any].self) {
+                array.append(dictionary)
+            } else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Unable to decode value"))
+            }
+        }
+        return array
+    }
+
+    mutating func decode(_ type: [Any].Type) throws -> [Any] {
+        var array: [Any] = []
+
+        while isAtEnd == false {
+            if let value = try? decode(Bool.self) {
+                array.append(value)
+            } else if let value = try? decode(Int.self) {
+                array.append(value)
+            } else if let value = try? decode(String.self) {
+                array.append(value)
+            } else if let value = try? decode(Double.self) {
+                array.append(value)
+            } else if let nestedDictionary = try? decode([String: Any].self) {
+                array.append(nestedDictionary)
+            } else if let nestedArray = try? decodeNestedArray([Any].self) {
+                array.append(nestedArray)
+            } else if let isValueNil = try? decodeNil(), isValueNil == true {
+                array.append(Optional<Any>.none as Any)
+            } else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Unable to decode value"))
+            }
+        }
+        return array
+    }
+
+    mutating func decode(_ type: [String: Any].Type) throws -> [String: Any] {
+        let container = try nestedContainer(keyedBy: JSONCodingKeys.self)
+        return try container.decode(type)
+    }
+
+    mutating func decodeNestedArray(_ type: [Any].Type) throws -> [Any] {
+        var container = try nestedUnkeyedContainer()
+        return try container.decode(type)
+    }
+}
+
+
+extension KeyedEncodingContainerProtocol where Key == JSONCodingKeys {
+    mutating func encode(_ value: [String: Any]) throws {
+        for (key, value) in value {
+            let key = JSONCodingKeys(stringValue: key)
+            switch value {
+            case let value as Bool:
+                try encode(value, forKey: key)
+            case let value as Int:
+                try encode(value, forKey: key)
+            case let value as String:
+                try encode(value, forKey: key)
+            case let value as Double:
+                try encode(value, forKey: key)
+            case let value as [String: Any]:
+                try encode(value, forKey: key)
+            case let value as [Any]:
+                try encode(value, forKey: key)
+            case Optional<Any>.none:
+                try encodeNil(forKey: key)
+            default:
+                throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: codingPath + [key], debugDescription: "Invalid JSON value"))
+            }
+        }
+    }
+}
+
+extension KeyedEncodingContainerProtocol {
+    mutating func encode(_ value: [String: Any], forKey key: Key) throws {
+        var container = nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
+        try container.encode(value)
+    }
+
+    mutating func encode(_ value: [Any], forKey key: Key) throws {
+        var container = nestedUnkeyedContainer(forKey: key)
+        try container.encode(value)
+    }
+
+    mutating func encodeIfPresent(_ value: [String: Any]?, forKey key: Key) throws {
+        guard let value = value else { return }
+
+        try encode(value, forKey: key)
+    }
+
+    mutating func encodeIfPresent(_ value: [Any]?, forKey key: Key) throws {
+        guard let value = value else { return }
+
+        try encode(value, forKey: key)
+    }
+}
+
+extension UnkeyedEncodingContainer {
+    mutating func encode(_ value: [Any]) throws {
+        for (index, value) in value.enumerated() {
+            switch value {
+            case let value as Bool:
+                try encode(value)
+            case let value as Int:
+                try encode(value)
+            case let value as String:
+                try encode(value)
+            case let value as Double:
+                try encode(value)
+            case let value as [String: Any]:
+                try encode(value)
+            case let value as [Any]:
+                try encodeNestedArray(value)
+            case Optional<Any>.none:
+                try encodeNil()
+            default:
+                let keys = JSONCodingKeys(intValue: index).map({ [ $0 ] }) ?? []
+                throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: codingPath + keys, debugDescription: "Invalid JSON value"))
+            }
+        }
+    }
+
+    mutating func encode(_ value: [String: Any]) throws {
+        var container = nestedContainer(keyedBy: JSONCodingKeys.self)
+        try container.encode(value)
+    }
+
+    mutating func encodeNestedArray(_ value: [Any]) throws {
+        var container = nestedUnkeyedContainer()
+        try container.encode(value)
+    }
+}

--- a/TidepoolKit/Internal/Extensions/Date.swift
+++ b/TidepoolKit/Internal/Extensions/Date.swift
@@ -1,0 +1,70 @@
+//
+//  Date.swift
+//  TidepoolKit
+//
+//  Created by Darin Krauss on 11/5/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+public extension Date {
+    init?(timeString: String) {
+        if let date = Date.timeFormatter.date(from: timeString) {
+            self = date.roundedToTimeInterval(TimeInterval.millisecond)
+        } else if let date = Date.timeFormatterAlternate.date(from: timeString) {
+            self = date.roundedToTimeInterval(TimeInterval.millisecond)
+        } else {
+            return nil
+        }
+    }
+
+    init?(deviceTimeString: String) {
+        if let date = Date.deviceTimeFormatter.date(from: deviceTimeString) {
+            self = date.roundedToTimeInterval(TimeInterval.millisecond)
+        } else if let date = Date.deviceTimeFormatterAlternate.date(from: deviceTimeString) {
+            self = date.roundedToTimeInterval(TimeInterval.millisecond)
+        } else {
+            return nil
+        }
+    }
+
+    var timeString: String {
+        return Date.timeFormatter.string(from: self.roundedToTimeInterval(TimeInterval.millisecond))
+    }
+
+    var deviceTimeString: String {
+        return Date.deviceTimeFormatter.string(from: self.roundedToTimeInterval(TimeInterval.millisecond))
+    }
+
+    static let timeFormatter: ISO8601DateFormatter = {
+        var timeFormatter = ISO8601DateFormatter()
+        timeFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return timeFormatter
+    }()
+
+    static let timeFormatterAlternate: ISO8601DateFormatter = {
+        var timeFormatter = ISO8601DateFormatter()
+        timeFormatter.formatOptions = [.withInternetDateTime]
+        return timeFormatter
+    }()
+
+    static let deviceTimeFormatter: ISO8601DateFormatter = {
+        var timeFormatter = ISO8601DateFormatter()
+        timeFormatter.formatOptions = [.withFullDate, .withFullTime, .withDashSeparatorInDate, .withColonSeparatorInTime, .withFractionalSeconds]
+        return timeFormatter
+    }()
+
+    static let deviceTimeFormatterAlternate: ISO8601DateFormatter = {
+        var timeFormatter = ISO8601DateFormatter()
+        timeFormatter.formatOptions = [.withFullDate, .withFullTime, .withDashSeparatorInDate, .withColonSeparatorInTime]
+        return timeFormatter
+    }()
+
+    private func roundedToTimeInterval(_ interval: TimeInterval) -> Date {
+        guard interval != 0 else {
+            return self
+        }
+        return Date(timeIntervalSinceReferenceDate: round(self.timeIntervalSinceReferenceDate / interval) * interval)
+    }
+}

--- a/TidepoolKit/Internal/Extensions/Date.swift
+++ b/TidepoolKit/Internal/Extensions/Date.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public extension Date {
+extension Date {
     init?(timeString: String) {
         if let date = Date.timeFormatter.date(from: timeString) {
             self = date.roundedToTimeInterval(TimeInterval.millisecond)

--- a/TidepoolKit/Internal/Extensions/TimeInterval.swift
+++ b/TidepoolKit/Internal/Extensions/TimeInterval.swift
@@ -1,0 +1,25 @@
+//
+//  TimeInterval.swift
+//  TidepoolKit
+//
+//  Created by Darin Krauss on 11/5/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+extension TimeInterval {
+    static let millisecond = milliseconds(1)
+
+    static func milliseconds(_ milliseconds: Double) -> TimeInterval {
+        return self.init(milliseconds: milliseconds)
+    }
+
+    init(milliseconds: Double) {
+        self.init(milliseconds / 1000)
+    }
+
+    var milliseconds: Double {
+        return self * 1000
+    }
+}

--- a/TidepoolKit/Internal/Responses/DataResponse.swift
+++ b/TidepoolKit/Internal/Responses/DataResponse.swift
@@ -1,0 +1,55 @@
+//
+//  DataResponse.swift
+//  TidepoolKit
+//
+//  Created by Darin Krauss on 2/28/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+struct DataResponse: Codable {
+    var data: [TDatum]
+    var malformed: [Int: [String: Any]]
+
+    init(data: [TDatum] = [], malformed: [Int: [String: Any]] = [:]) {
+        self.data = data
+        self.malformed = malformed
+    }
+    
+    init(from decoder: Decoder) throws {
+        self.init()
+        var container = try decoder.unkeyedContainer()
+        while !container.isAtEnd {
+            let superDecoder = try container.superDecoder()
+            let superContainer = try superDecoder.container(keyedBy: CodingKeys.self)
+            do {
+                var datum: TDatum?
+                let type = try superContainer.decode(TDatum.DatumType.self, forKey: .type)
+                switch type {
+                case .cbg:
+                    datum = try TCBGDatum(from: superDecoder)
+                case .food:
+                    datum = try TFoodDatum(from: superDecoder)
+                default:
+                    break // DEPRECATED: Ignore
+                }
+                if let datum = datum {
+                    data.append(datum)
+                }
+            } catch let error {
+                TSharedLogging.error((error as CustomDebugStringConvertible).debugDescription)
+                let malformedContainer = try superDecoder.container(keyedBy: JSONCodingKeys.self)
+                malformed[container.currentIndex] = try malformedContainer.decode([String: Any].self)
+            }
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try data.encode(to: encoder)
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case subType
+        case deliveryType
+    }
+}

--- a/TidepoolKit/Internal/Responses/LegacyResponse.swift
+++ b/TidepoolKit/Internal/Responses/LegacyResponse.swift
@@ -1,0 +1,28 @@
+//
+//  LegacyResponse.swift
+//  TidepoolKit
+//
+//  Created by Darin Krauss on 2/25/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+struct LegacyResponse {
+    struct Success<D>: Codable where D: Codable {
+        var data: D
+        var meta: Meta?
+    }
+
+    struct Failure: Codable {
+        var errors: [TError.Detail]
+        var meta: Meta?
+    }
+
+    struct Meta: Codable {
+        var trace: Trace?
+
+        struct Trace: Codable {
+            var request: String?
+            var session: String?
+        }
+    }
+}

--- a/TidepoolKit/Internal/Responses/LoginResponse.swift
+++ b/TidepoolKit/Internal/Responses/LoginResponse.swift
@@ -6,29 +6,23 @@
 //  Copyright © 2020 Tidepool Project. All rights reserved.
 //
 
-struct LoginResponse: RawRepresentable {
-    typealias RawValue = [String: Any]
-
-    let userID: String
+struct LoginResponse: Codable, Equatable {
+    let userId: String
     let email: String
     let emailVerified: Bool
     let termsAccepted: String?
 
-    init?(rawValue: RawValue) {
-        guard let userID = rawValue["userid"] as? String,
-            let email = rawValue["username"] as? String,
-            let emailVerified = rawValue["emailVerified"] as? Bool else
-        {
-            return nil
-        }
-
-        self.userID = userID
+    init(userId: String, email: String, emailVerified: Bool = false, termsAccepted: String? = nil) {
+        self.userId = userId
         self.email = email
         self.emailVerified = emailVerified
-        self.termsAccepted = rawValue["termsAccepted"] as? String
+        self.termsAccepted = termsAccepted
     }
 
-    var rawValue: RawValue {
-        fatalError("rawValue has not been implemented")
+    private enum CodingKeys: String, CodingKey {
+        case userId = "userid"
+        case email = "username"
+        case emailVerified
+        case termsAccepted
     }
 }

--- a/TidepoolKit/Model/Datum/TCBGDatum.swift
+++ b/TidepoolKit/Model/Datum/TCBGDatum.swift
@@ -1,0 +1,41 @@
+//
+//  TCBGDatum.swift
+//  TidepoolKit
+//
+//  Created by Larry Kenyon on 8/23/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+public class TCBGDatum: TDatum, Decodable {
+    public typealias Units = TBloodGlucose.Units
+
+    public var value: Double?
+    public var units: Units?
+
+    public init(time: Date, value: Double, units: Units) {
+        self.value = value
+        self.units = units
+        super.init(.cbg, time: time)
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.value = try container.decodeIfPresent(Double.self, forKey: .value)
+        self.units = try container.decodeIfPresent(Units.self, forKey: .units)
+        try super.init(.cbg, from: decoder)
+    }
+
+    public override func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(value, forKey: .value)
+        try container.encodeIfPresent(units, forKey: .units)
+        try super.encode(to: encoder)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case value
+        case units
+    }
+}

--- a/TidepoolKit/Model/Datum/TDatum.swift
+++ b/TidepoolKit/Model/Datum/TDatum.swift
@@ -1,0 +1,214 @@
+//
+//  TDatum.swift
+//  TidepoolKit
+//
+//  Created by Larry Kenyon on 8/23/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+public class TDatum: Encodable {
+    public enum DatumType: String, Codable {
+        case basal
+        case bloodKetone
+        case bolus
+        case calculator = "wizard"
+        case cbg
+        case cgmSettings
+        case deviceEvent
+        case food
+        case insulin
+        case physicalActivity
+        case pumpSettings
+        case reportedState
+        case smbg
+        case upload // DEPRECATED: Presence here allows decoding to ignore without failing
+        case water
+    }
+
+    public let type: DatumType
+    public var time: Date
+
+    public var annotations: [TDictionary]?
+    public var associations: [TAssociation]?
+    public var clockDriftOffset: Int?
+    public var conversionOffset: Int?
+    public var dataSetId: String?
+    public var deviceId: String?
+    public var deviceTime: String?
+    public var id: String?
+    public var location: TLocation?
+    public var notes: [String]?
+    public var origin: TOrigin?
+    public var payload: TDictionary?
+    public var tags: [String]?
+    public var timezone: String?
+    public var timezoneOffset: Int?
+
+    public init(_ type: DatumType,
+                time: Date,
+                annotations: [TDictionary]? = nil,
+                associations: [TAssociation]? = nil,
+                clockDriftOffset: Int? = nil,
+                conversionOffset: Int? = nil,
+                dataSetId: String? = nil,
+                deviceId: String? = nil,
+                deviceTime: String? = nil,
+                id: String? = nil,
+                location: TLocation? = nil,
+                notes: [String]? = nil,
+                origin: TOrigin? = nil,
+                payload: TDictionary? = nil,
+                tags: [String]? = nil,
+                timezone: String? = nil,
+                timezoneOffset: Int? = nil) {
+        self.type = type
+        self.time = time
+        self.annotations = annotations
+        self.associations = associations
+        self.clockDriftOffset = clockDriftOffset
+        self.conversionOffset = conversionOffset
+        self.dataSetId = dataSetId
+        self.deviceId = deviceId
+        self.deviceTime = deviceTime
+        self.id = id
+        self.location = location
+        self.notes = notes
+        self.origin = origin
+        self.payload = payload
+        self.tags = tags
+        self.timezone = timezone
+        self.timezoneOffset = timezoneOffset
+    }
+
+    init(_ expectedType: DatumType, from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.type = try container.decode(DatumType.self, forKey: .type)
+        guard self.type == expectedType else {
+            throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unexpected type '\(self.type)'")
+        }
+        self.time = try container.decode(Date.self, forKey: .time)
+        self.annotations = try container.decodeIfPresent([TDictionary].self, forKey: .annotations)
+        self.associations = try container.decodeIfPresent([TAssociation].self, forKey: .associations)
+        self.clockDriftOffset = try container.decodeIfPresent(Int.self, forKey: .clockDriftOffset)
+        self.conversionOffset = try container.decodeIfPresent(Int.self, forKey: .conversionOffset)
+        self.dataSetId = try container.decodeIfPresent(String.self, forKey: .dataSetId)
+        self.deviceId = try container.decodeIfPresent(String.self, forKey: .deviceId)
+        self.deviceTime = try container.decodeIfPresent(String.self, forKey: .deviceTime)
+        self.id = try container.decodeIfPresent(String.self, forKey: .id)
+        self.location = try container.decodeIfPresent(TLocation.self, forKey: .location)
+        self.notes = try container.decodeIfPresent([String].self, forKey: .notes)
+        self.origin = try container.decodeIfPresent(TOrigin.self, forKey: .origin)
+        self.payload = try container.decodeIfPresent(TDictionary.self, forKey: .payload)
+        self.tags = try container.decodeIfPresent([String].self, forKey: .tags)
+        self.timezone = try container.decodeIfPresent(String.self, forKey: .timezone)
+        self.timezoneOffset = try container.decodeIfPresent(Int.self, forKey: .timezoneOffset)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encode(time, forKey: .time)
+        try container.encodeIfPresent(annotations, forKey: .annotations)
+        try container.encodeIfPresent(associations, forKey: .associations)
+        try container.encodeIfPresent(clockDriftOffset, forKey: .clockDriftOffset)
+        try container.encodeIfPresent(conversionOffset, forKey: .conversionOffset)
+        try container.encodeIfPresent(dataSetId, forKey: .dataSetId)
+        try container.encodeIfPresent(deviceId, forKey: .deviceId)
+        try container.encodeIfPresent(deviceTime, forKey: .deviceTime)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(location, forKey: .location)
+        try container.encodeIfPresent(notes, forKey: .notes)
+        try container.encodeIfPresent(origin, forKey: .origin)
+        try container.encodeIfPresent(payload, forKey: .payload)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(timezone, forKey: .timezone)
+        try container.encodeIfPresent(timezoneOffset, forKey: .timezoneOffset)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case time
+        case annotations
+        case associations
+        case clockDriftOffset
+        case conversionOffset
+        case dataSetId = "uploadId"
+        case deviceId
+        case deviceTime
+        case id
+        case location
+        case notes
+        case origin
+        case payload
+        case tags
+        case timezone
+        case timezoneOffset
+    }
+}
+
+extension TDatum {
+    public struct Filter {
+        public var startDate: Date?
+        public var endDate: Date?
+        public var dataSetId: String?
+        public var deviceId: String?
+        public var carelink: Bool?
+        public var dexcom: Bool?
+        public var medtronic: Bool?
+        public var latest: Bool?
+        public var types: [String]?
+        public var subTypes: [String]?
+
+        public init(startDate: Date? = nil, endDate: Date? = nil, dataSetId: String? = nil, deviceId: String? = nil,
+                    carelink: Bool? = nil, dexcom: Bool? = nil, medtronic: Bool? = nil, latest: Bool? = nil,
+                    types: [String]? = nil, subTypes: [String]? = nil) {
+            self.startDate = startDate
+            self.endDate = endDate
+            self.dataSetId = dataSetId
+            self.deviceId = deviceId
+            self.carelink = carelink
+            self.dexcom = dexcom
+            self.medtronic = medtronic
+            self.latest = latest
+            self.types = types
+            self.subTypes = subTypes
+        }
+
+        public var queryItems: [URLQueryItem]? {
+            var queryItems: [URLQueryItem] = []
+            if let startDate = startDate {
+                queryItems.append(URLQueryItem(name: "startDate", value: startDate.timeString))
+            }
+            if let endDate = endDate {
+                queryItems.append(URLQueryItem(name: "endDate", value: endDate.timeString))
+            }
+            if let dataSetId = dataSetId {
+                queryItems.append(URLQueryItem(name: "uploadId", value: dataSetId))
+            }
+            if let deviceId = deviceId {
+                queryItems.append(URLQueryItem(name: "deviceId", value: deviceId))
+            }
+            if let carelink = carelink {
+                queryItems.append(URLQueryItem(name: "carelink", value: carelink.description))
+            }
+            if let dexcom = dexcom {
+                queryItems.append(URLQueryItem(name: "dexcom", value: dexcom.description))
+            }
+            if let medtronic = medtronic {
+                queryItems.append(URLQueryItem(name: "medtronic", value: medtronic.description))
+            }
+            if let latest = latest {
+                queryItems.append(URLQueryItem(name: "latest", value: latest.description))
+            }
+            if let types = types {
+                queryItems.append(URLQueryItem(name: "types", value: types.joined(separator: ",")))
+            }
+            if let subTypes = subTypes {
+                queryItems.append(URLQueryItem(name: "subTypes", value: subTypes.joined(separator: ",")))
+            }
+            return queryItems
+        }
+    }
+}

--- a/TidepoolKit/Model/Datum/TFoodDatum.swift
+++ b/TidepoolKit/Model/Datum/TFoodDatum.swift
@@ -1,0 +1,184 @@
+//
+//  TFoodDatum.swift
+//  TidepoolKit
+//
+//  Created by Larry Kenyon on 8/23/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+public class TFoodDatum: TDatum, Decodable {
+    public enum Meal: String, Codable {
+        case breakfast
+        case lunch
+        case dinner
+        case snack
+        case other
+    }
+
+    public var name: String?
+    public var amount: Amount?
+    public var brand: String?
+    public var code: String?
+    public var meal: Meal?
+    public var mealOther: String?
+    public var nutrition: Nutrition?
+    public var ingredients: [Ingredient]?
+
+    public init(time: Date, name: String? = nil, amount: Amount? = nil, brand: String? = nil, code: String? = nil, meal: Meal? = nil, mealOther: String? = nil, nutrition: Nutrition? = nil, ingredients: [Ingredient]? = nil) {
+        self.name = name
+        self.amount = amount
+        self.brand = brand
+        self.code = code
+        self.meal = meal
+        self.mealOther = mealOther
+        self.nutrition = nutrition
+        self.ingredients = ingredients
+        super.init(.food, time: time)
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.name = try container.decodeIfPresent(String.self, forKey: .name)
+        self.amount = try container.decodeIfPresent(Amount.self, forKey: .amount)
+        self.brand = try container.decodeIfPresent(String.self, forKey: .brand)
+        self.code = try container.decodeIfPresent(String.self, forKey: .code)
+        self.meal = try container.decodeIfPresent(Meal.self, forKey: .meal)
+        self.mealOther = try container.decodeIfPresent(String.self, forKey: .mealOther)
+        self.nutrition = try container.decodeIfPresent(Nutrition.self, forKey: .nutrition)
+        self.ingredients = try container.decodeIfPresent([Ingredient].self, forKey: .ingredients)
+        try super.init(.food, from: decoder)
+    }
+
+    public override func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(amount, forKey: .amount)
+        try container.encodeIfPresent(brand, forKey: .brand)
+        try container.encodeIfPresent(code, forKey: .code)
+        try container.encodeIfPresent(meal, forKey: .meal)
+        try container.encodeIfPresent(mealOther, forKey: .mealOther)
+        try container.encodeIfPresent(nutrition, forKey: .nutrition)
+        try container.encodeIfPresent(ingredients, forKey: .ingredients)
+        try super.encode(to: encoder)
+    }
+
+    public struct Amount: Codable, Equatable {
+        public var value: Double?
+        public var units: String?
+
+        public init(_ value: Double, _ units: String) {
+            self.value = value
+            self.units = units
+        }
+    }
+
+    public struct Nutrition: Codable, Equatable {
+        public var carbohydrate: Carbohydrate?
+        public var fat: Fat?
+        public var protein: Protein?
+        public var energy: Energy?
+
+        public init(carbohydrate: Carbohydrate? = nil, fat: Fat? = nil, protein: Protein? = nil, energy: Energy? = nil) {
+            self.carbohydrate = carbohydrate
+            self.fat = fat
+            self.protein = protein
+            self.energy = energy
+        }
+
+        public struct Carbohydrate: Codable, Equatable {
+            public enum Units: String, Codable {
+                case grams
+            }
+
+            public var net: Double?
+            public var sugars: Double?
+            public var dietaryFiber: Double?
+            public var total: Double?
+            public var units: Units?
+
+            public init(net: Double? = nil, sugars: Double? = nil, dietaryFiber: Double? = nil, total: Double? = nil, units: Units = .grams) {
+                self.net = net
+                self.sugars = sugars
+                self.dietaryFiber = dietaryFiber
+                self.total = total
+                self.units = units
+            }
+        }
+
+        public struct Fat: Codable, Equatable {
+            public enum Units: String, Codable {
+                case grams
+            }
+
+            public var total: Double?
+            public var units: Units?
+
+            public init(_ total: Double, _ units: Units = .grams) {
+                self.total = total
+                self.units = units
+            }
+        }
+
+        public struct Protein: Codable, Equatable {
+            public enum Units: String, Codable {
+                case grams
+            }
+
+            public var total: Double?
+            public var units: Units?
+
+            public init(_ total: Double, _ units: Units = .grams) {
+                self.total = total
+                self.units = units
+            }
+        }
+
+        public struct Energy: Codable, Equatable {
+            public enum Units: String, Codable {
+                case calories
+                case joules
+                case kilocalories
+                case kilojoules
+            }
+
+            public var value: Double?
+            public var units: Units?
+
+            public init(_ value: Double, _ units: Units) {
+                self.value = value
+                self.units = units
+            }
+        }
+    }
+
+    public struct Ingredient: Codable, Equatable {
+        public var name: String?
+        public var amount: Amount?
+        public var brand: String?
+        public var code: String?
+        public var nutrition: Nutrition?
+        public var ingredients: [Ingredient]?
+
+        public init(name: String? = nil, amount: Amount? = nil, brand: String? = nil, code: String? = nil, nutrition: Nutrition? = nil, ingredients: [Ingredient]? = nil) {
+            self.name = name
+            self.amount = amount
+            self.brand = brand
+            self.code = code
+            self.nutrition = nutrition
+            self.ingredients = ingredients
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case amount
+        case brand
+        case code
+        case meal
+        case mealOther
+        case nutrition
+        case ingredients
+    }
+}

--- a/TidepoolKit/Model/TAssociation.swift
+++ b/TidepoolKit/Model/TAssociation.swift
@@ -1,0 +1,33 @@
+//
+//  TAssociation.swift
+//  TidepoolKit
+//
+//  Created by Larry Kenyon on 8/23/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+public struct TAssociation: Codable, Equatable {
+    public enum AssociationType: String, Codable {
+        case blob
+        case datum
+        case image
+        case url
+    }
+
+    public var type: AssociationType?
+    public var id: String?
+    public var url: String?
+    public var reason: String?
+
+    public init(type: AssociationType, id: String, reason: String? = nil) {
+        self.type = type
+        self.id = id
+        self.reason = reason
+    }
+
+    public init(type: AssociationType, url: String, reason: String? = nil) {
+        self.type = type
+        self.url = url
+        self.reason = reason
+    }
+}

--- a/TidepoolKit/Model/TBloodGlucose.swift
+++ b/TidepoolKit/Model/TBloodGlucose.swift
@@ -1,0 +1,40 @@
+//
+//  TBloodGlucose.swift
+//  TidepoolKit
+//
+//  Created by Darin Krauss on 11/1/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+public struct TBloodGlucose {
+    public enum Units: String, Codable {
+        case milligramsPerDeciliter = "mg/dL"
+        case millimolesPerLiter = "mmol/L"
+    }
+
+    public struct Target: Codable, Equatable {
+        public var target: Double?
+        public var range: Double?
+        public var low: Double?
+        public var high: Double?
+
+        public init(target: Double) {
+            self.target = target
+        }
+
+        public init(target: Double, range: Double) {
+            self.target = target
+            self.range = range
+        }
+
+        public init(target: Double, high: Double) {
+            self.target = target
+            self.high = high
+        }
+
+        public init(low: Double, high: Double) {
+            self.low = low
+            self.high = high
+        }
+    }
+}

--- a/TidepoolKit/Model/TDataSet.swift
+++ b/TidepoolKit/Model/TDataSet.swift
@@ -1,0 +1,180 @@
+//
+//  TDataSet.swift
+//  TidepoolKit
+//
+//  Created by Larry Kenyon on 8/20/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+public struct TDataSet: Codable, Equatable {
+    public enum DataSetType: String, Codable {
+        case continuous
+        case normal
+    }
+
+    public enum DeviceTag: String, Codable {
+        case bgm
+        case cgm
+        case insulinPump = "insulin-pump"
+    }
+
+    public enum TimeProcessing: String, Codable {
+        case acrossTheBoardTimezone = "across-the-board-timezone"
+        case none
+        case utcBootstrapping = "utc-bootstrapping"
+    }
+
+    public var byUser: String?
+    public var client: Client?
+    public var computerTime: String?
+    public var conversionOffset: Int?
+    public var createdTime: Date?
+    public var dataSetType: DataSetType?
+    public var deduplicator: Deduplicator?
+    public var deviceId: String?
+    public var deviceManufacturers: [String]?
+    public var deviceModel: String?
+    public var deviceSerialNumber: String?
+    public var deviceTags: [DeviceTag]?
+    public var id: String?
+    public var modifiedTime: Date?
+    public var time: Date?
+    public var timeProcessing: TimeProcessing?
+    public var timezone: String?
+    public var timezoneOffset: Int?
+    public let type: String = "upload"
+    public var uploadId: String?
+    public var version: String?
+
+    public init(dataSetType: DataSetType, client: Client, deduplicator: Deduplicator) {
+        self.dataSetType = dataSetType
+        self.client = client
+        self.deduplicator = deduplicator
+    }
+
+    public init(byUser: String? = nil,
+                client: Client? = nil,
+                computerTime: String? = nil,
+                conversionOffset: Int? = nil,
+                createdTime: Date? = nil,
+                dataSetType: DataSetType? = nil,
+                deduplicator: Deduplicator? = nil,
+                deviceId: String? = nil,
+                deviceManufacturers: [String]? = nil,
+                deviceModel: String? = nil,
+                deviceSerialNumber: String? = nil,
+                deviceTags: [DeviceTag]? = nil,
+                id: String? = nil,
+                modifiedTime: Date? = nil,
+                time: Date? = nil,
+                timeProcessing: TimeProcessing? = nil,
+                timezone: String? = nil,
+                timezoneOffset: Int? = nil,
+                uploadId: String? = nil,
+                version: String? = nil) {
+        self.byUser = byUser
+        self.client = client
+        self.computerTime = computerTime
+        self.conversionOffset = conversionOffset
+        self.createdTime = createdTime
+        self.dataSetType = dataSetType
+        self.deduplicator = deduplicator
+        self.deviceId = deviceId
+        self.deviceManufacturers = deviceManufacturers
+        self.deviceModel = deviceModel
+        self.deviceSerialNumber = deviceSerialNumber
+        self.deviceTags = deviceTags
+        self.id = id
+        self.modifiedTime = modifiedTime
+        self.time = time
+        self.timeProcessing = timeProcessing
+        self.timezone = timezone
+        self.timezoneOffset = timezoneOffset
+        self.uploadId = uploadId
+        self.version = version
+    }
+
+    public struct Client: Codable, Equatable {
+        public var name: String?
+        public var version: String?
+        public var payload: TDictionary?
+
+        public init(name: String, version: String, payload: TDictionary? = nil) {
+            self.name = name
+            self.version = version
+            self.payload = payload
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case name
+            case version
+            case payload = "private"
+        }
+    }
+
+    public struct Deduplicator: Codable, Equatable {
+        public enum Name: String, Codable {
+            case dataSetDeleteOrigin = "org.tidepool.deduplicator.dataset.delete.origin"
+            case deviceDeactivateHash = "org.tidepool.deduplicator.device.deactivate.hash"
+            case deviceTruncateDataSet = "org.tidepool.deduplicator.device.truncate.dataset"
+            case none = "org.tidepool.deduplicator.none"
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let nameRawValue = try container.decode(String.self)
+                if let name = Name(rawValue: nameRawValue) {
+                    self = name
+                } else if let name = legacyNames[nameRawValue] {
+                    self = name
+                } else {
+                    throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unknown name '\(nameRawValue)'")
+                }
+            }
+        }
+
+        public var name: Name
+        public var version: String?
+
+        public init(name: Name, version: String? = nil) {
+            self.name = name
+            self.version = version
+        }
+
+        private static let legacyNames: [String: Name] = [
+            "org.tidepool.continuous.origin": .dataSetDeleteOrigin,
+            "org.tidepool.hash-deactivate-old": .deviceDeactivateHash,
+            "org.tidepool.truncate": .deviceTruncateDataSet,
+            "org.tidepool.continuous": .none
+        ]
+    }
+}
+
+extension TDataSet {
+    public struct Filter {
+        public var clientName: String?
+        public var deleted: Bool?
+        public var deviceId: String?
+
+        public init(clientName: String? = nil, deleted: Bool? = nil, deviceId: String? = nil) {
+            self.clientName = clientName
+            self.deleted = deleted
+            self.deviceId = deviceId
+        }
+
+        public var queryItems: [URLQueryItem]? {
+            var queryItems: [URLQueryItem] = []
+            if let clientName = clientName {
+                queryItems.append(URLQueryItem(name: "client.name", value: clientName))
+            }
+            if let deleted = deleted {
+                queryItems.append(URLQueryItem(name: "deleted", value: deleted.description))
+            }
+            if let deviceId = deviceId {
+                queryItems.append(URLQueryItem(name: "deviceId", value: deviceId))
+            }
+            return queryItems
+        }
+    }
+}

--- a/TidepoolKit/Model/TDictionary.swift
+++ b/TidepoolKit/Model/TDictionary.swift
@@ -1,0 +1,42 @@
+//
+//  TDictionary.swift
+//  TidepoolKit
+//
+//  Created by Darin Krauss on 3/3/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+public struct TDictionary {
+    public var dictionary: [String: Any]
+
+    public init(_ dictionary: [String: Any] = [:]) {
+        self.dictionary = dictionary
+    }
+
+    public var isEmpty: Bool { dictionary.isEmpty }
+
+    public subscript(key: String) -> Any? {
+        get { dictionary[key] }
+        set(newValue) { dictionary[key] = newValue }
+    }
+}
+
+extension TDictionary: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: JSONCodingKeys.self)
+        self.dictionary = try container.decode([String: Any].self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: JSONCodingKeys.self)
+        try container.encode(dictionary)
+    }
+}
+
+extension TDictionary: Equatable {
+    public static func == (lhs: TDictionary, rhs: TDictionary) -> Bool {
+        return NSDictionary(dictionary: lhs.dictionary).isEqual(to: rhs.dictionary)
+    }
+}

--- a/TidepoolKit/Model/TLocation.swift
+++ b/TidepoolKit/Model/TLocation.swift
@@ -1,0 +1,95 @@
+//
+//  TLocation.swift
+//  TidepoolKit
+//
+//  Created by Larry Kenyon on 8/23/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+public struct TLocation: Codable, Equatable {
+    public var name: String?
+    public var gps: GPS?
+
+    public init(name: String? = nil, gps: GPS? = nil) {
+        self.name = name
+        self.gps = gps
+    }
+
+    public struct GPS: Codable, Equatable {
+        public var latitude: Latitude?
+        public var longitude: Longitude?
+        public var elevation: Elevation?
+        public var floor: Int?
+        public var horizontalAccuracy: Accuracy?
+        public var verticalAccuracy: Accuracy?
+        public var origin: TOrigin?
+
+        public init(latitude: Latitude? = nil, longitude: Longitude? = nil, elevation: Elevation? = nil, floor: Int? = nil, horizontalAccuracy: Accuracy? = nil, verticalAccuracy: Accuracy? = nil, origin: TOrigin? = nil) {
+            self.latitude = latitude
+            self.longitude = longitude
+            self.elevation = elevation
+            self.floor = floor
+            self.horizontalAccuracy = horizontalAccuracy
+            self.verticalAccuracy = verticalAccuracy
+            self.origin = origin
+        }
+
+        public struct Latitude: Codable, Equatable {
+            public enum Units: String, Codable {
+                case degrees
+            }
+
+            public var value: Double?
+            public var units: Units?
+
+            public init(_ value: Double, _ units: Units = .degrees) {
+                self.value = value
+                self.units = units
+            }
+        }
+
+        public struct Longitude: Codable, Equatable {
+            public enum Units: String, Codable {
+                case degrees
+            }
+
+            public var value: Double?
+            public var units: Units?
+
+            public init(_ value: Double, _ units: Units = .degrees) {
+                self.value = value
+                self.units = units
+            }
+        }
+
+        public struct Elevation: Codable, Equatable {
+            public enum Units: String, Codable {
+                case feet
+                case meters
+            }
+
+            public var value: Double?
+            public var units: Units?
+
+            public init(_ value: Double, _ units: Units) {
+                self.value = value
+                self.units = units
+            }
+        }
+
+        public struct Accuracy: Codable, Equatable {
+            public enum Units: String, Codable {
+                case feet
+                case meters
+            }
+
+            public var value: Double?
+            public var units: Units?
+
+            public init(_ value: Double, _ units: Units) {
+                self.value = value
+                self.units = units
+            }
+        }
+    }
+}

--- a/TidepoolKit/Model/TOrigin.swift
+++ b/TidepoolKit/Model/TOrigin.swift
@@ -1,0 +1,33 @@
+//
+//  TOrigin.swift
+//  TidepoolKit
+//
+//  Created by Larry Kenyon on 8/23/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+public struct TOrigin: Codable, Equatable {
+    public enum OriginType: String, Codable {
+        case device
+        case manual
+        case service
+    }
+
+    public var id: String?
+    public var name: String?
+    public var version: String?
+    public var type: OriginType?
+    public var time: Date?
+    public var payload: TDictionary?
+
+    public init(id: String? = nil, name: String? = nil, version: String? = nil, type: OriginType? = nil, time: Date? = nil, payload: TDictionary? = nil) {
+        self.id = id
+        self.name = name
+        self.version = version
+        self.type = type
+        self.time = time
+        self.payload = payload
+    }
+}

--- a/TidepoolKit/Model/TProfile.swift
+++ b/TidepoolKit/Model/TProfile.swift
@@ -1,0 +1,49 @@
+//
+//  TProfile.swift
+//  TidepoolKit
+//
+//  Created by Darin Krauss on 2/21/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+public struct TProfile: Codable, Equatable {
+    public var fullName: String?
+    public var patient: Patient?
+
+    public init(fullName: String, patient: Patient? = nil) {
+        self.fullName = fullName
+        self.patient = patient
+    }
+
+    public struct Patient: Codable, Equatable {
+        public var isOtherPerson: Bool?
+        public var fullName: String?
+        public var birthday: String?
+        public var diagnosisDate: String?
+        public var diagnosisType: String?
+        public var biologicalSex: String?
+        public var targetTimezone: String?
+        public var targetDevices: [String]?
+        public var about: String?
+
+        public init(isOtherPerson: Bool,
+                    fullName: String,
+                    birthday: String,
+                    diagnosisDate: String,
+                    diagnosisType: String? = nil,
+                    biologicalSex: String? = nil,
+                    targetTimezone: String? = nil,
+                    targetDevices: [String]? = nil,
+                    about: String? = nil) {
+            self.isOtherPerson = isOtherPerson
+            self.fullName = fullName
+            self.birthday = birthday
+            self.diagnosisDate = diagnosisDate
+            self.diagnosisType = diagnosisType
+            self.biologicalSex = biologicalSex
+            self.targetTimezone = targetTimezone
+            self.targetDevices = targetDevices
+            self.about = about
+        }
+    }
+}

--- a/TidepoolKit/TAPI.swift
+++ b/TidepoolKit/TAPI.swift
@@ -29,11 +29,16 @@ public class TAPI {
     }
 
     /// Create a new instance of TAPI. Automatically lookup additional environments in the background.
-    public init() {
+    ///
+    /// - Parameters:
+    ///   - automaticallyFetchEnvironments: Automatically fetch an updated list of environments when created.
+    public init(automaticallyFetchEnvironments: Bool = true) {
         self.environmentsLocked = Locked(TAPI.defaultEnvironments)
         self.urlSessionConfigurationLocked = Locked(TAPI.defaultURLSessionConfiguration)
         self.urlSessionLocked = Locked(nil)
-        fetchEnvironments()
+        if automaticallyFetchEnvironments {
+            fetchEnvironments()
+        }
     }
 
     // MARK: - Environment
@@ -47,11 +52,8 @@ public class TAPI {
             DNS.lookupSRVRecords(for: TAPI.DNSSRVRecordsDomainName) { result in
                 switch result {
                 case .failure(let error):
-                    if let completion = completion {
-                        completion(.failure(.network(error)))
-                    } else {
-                        TSharedLogging.error("Failure during DNS SRV record lookup: \(error)")
-                    }
+                    TSharedLogging.error("Failure during DNS SRV record lookup [\(error)]")
+                    completion?(.failure(.network(error)))
                 case .success(let records):
                     var records = records + TAPI.DNSSRVRecordsImplicit
                     records = records.map { record in
@@ -62,11 +64,8 @@ public class TAPI {
                     }
                     let environments = records.sorted().environments
                     self.environmentsLocked.mutate { $0 = environments }
-                    if let completion = completion {
-                        completion(.success(environments))
-                    } else {
-                        TSharedLogging.debug("Successful DNS SRV record lookup")
-                    }
+                    TSharedLogging.debug("Successful DNS SRV record lookup")
+                    completion?(.success(environments))
                 }
             }
         }
@@ -84,25 +83,25 @@ public class TAPI {
     ///   - completion: The completion function to invoke with the newly created session or an error.
     public func login(environment: TEnvironment, email: String, password: String, completion: @escaping (Result<TSession, TError>) -> Void) {
         var request = createRequest(environment: environment, method: "POST", path: "/auth/login")
-        request.setValue(basicAuthorizationFromCredentials(email: email, password: password), forHTTPHeaderField: "Authorization")
-        performRequest(request) { (result: HTTPResult) -> Void in
+        request?.setValue(basicAuthorizationFromCredentials(email: email, password: password), forHTTPHeaderField: "Authorization")
+        performRequest(request) { (result: DecodableHTTPResult<LoginResponse>) -> Void in
             switch result {
             case .failure(let error):
-                completion(.failure(error))
-            case .success(let response, let data):
-                if let data = data {
-                    if let dictionaryArray = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                        let loginResponse = LoginResponse(rawValue: dictionaryArray) {
-                        if let authenticationToken = response.value(forHTTPHeaderField: "X-Tidepool-Session-Token"), !authenticationToken.isEmpty {
-                            completion(.success(TSession(environment: environment, authenticationToken: authenticationToken, userID: loginResponse.userID)))
-                        } else {
-                            completion(.failure(.responseNotAuthenticated(response, data)))
-                        }
+                switch error {
+                case .requestNotAuthorized(let response, let data):     // CUSTOM: Backend currently returns status code 403 to imply email not verified
+                    completion(.failure(.requestEmailNotVerified(response, data)))
+                default:
+                    completion(.failure(error))
+                }
+            case .success(let response, let data, let loginResponse):
+                if let authenticationToken = response.value(forHTTPHeaderField: "X-Tidepool-Session-Token"), !authenticationToken.isEmpty {
+                    if loginResponse.termsAccepted?.isEmpty == false {     // CUSTOM: Backend does not currently explicitly check if terms are accepted
+                        completion(.success(TSession(environment: environment, authenticationToken: authenticationToken, userId: loginResponse.userId)))
                     } else {
-                        completion(.failure(.responseMalformedJSON(response, data)))
+                        completion(.failure(.requestTermsOfServiceNotAccepted(response, data)))
                     }
                 } else {
-                    completion(.failure(.responseMissingJSON(response)))
+                    completion(.failure(.responseNotAuthenticated(response, data)))
                 }
             }
         }
@@ -131,7 +130,7 @@ public class TAPI {
                 completion(.failure(error))
             case .success(let response, let data):
                 if let authenticationToken = response.value(forHTTPHeaderField: "X-Tidepool-Session-Token"), !authenticationToken.isEmpty {
-                    completion(.success(TSession(environment: session.environment, authenticationToken: authenticationToken, userID: session.userID, trace: session.trace)))
+                    completion(.success(TSession(environment: session.environment, authenticationToken: authenticationToken, userId: session.userId, trace: session.trace)))
                 } else {
                     completion(.failure(.responseNotAuthenticated(response, data)))
                 }
@@ -145,32 +144,186 @@ public class TAPI {
     ///   - session: The Tidepool API session to logout.
     ///   - completion: The completion function to invoke with any error.
     public func logout(session: TSession, completion: @escaping (TError?) -> Void) {
-        performRequest(createRequest(session: session, method: "POST", path: "/auth/logout"), completion: completion)
+        let request = createRequest(session: session, method: "POST", path: "/auth/logout")
+        performRequest(request, completion: completion)
     }
 
-    // MARK: - Internal Implementation
+    // MARK: - Profile
 
-    private func createRequest(session: TSession, method: String, path: String, queryItems: [URLQueryItem]? = nil) -> URLRequest {
-        var request = createRequest(environment: session.environment, method: method, path: path, queryItems: queryItems)
-        request.setValue(session.authenticationToken, forHTTPHeaderField: "X-Tidepool-Session-Token")
-        if let trace = session.trace {
-            request.setValue(trace, forHTTPHeaderField: "X-Tidepool-Trace-Session")
+    /// Get the profile for the specified user id. If no user id is specified, then the session user id is used.
+    ///
+    /// - Parameters:
+    ///   - userId: The user id for which to get the profile. If no user id is specified, then the session user id is used.
+    ///   - session: The Tidepool API session to use.
+    ///   - completion: The completion function to invoke with any error.
+    public func getProfile(userId: String? = nil, session: TSession, completion: @escaping (Result<TProfile, TError>) -> Void) {
+        let request = createRequest(session: session, method: "GET", path: "/metadata/\(userId ?? session.userId)/profile")
+        performRequest(request, completion: completion)
+    }
+
+    // MARK: - Data Sets
+
+    /// List the data sets for the specified user id. If no user id is specified, then the session user id is used. A filter can
+    /// be specified to reduce the data sets returned.
+    ///
+    /// - Parameters:
+    ///   - filter: The filter to use when requesting the data sets.
+    ///   - userId: The user id for which to get the data sets. If no user id is specified, then the session user id is used.
+    ///   - session: The Tidepool API session to use.
+    ///   - completion: The completion function to invoke with any error.
+    public func listDataSets(filter: TDataSet.Filter? = nil, userId: String? = nil, session: TSession, completion: @escaping (Result<[TDataSet], TError>) -> Void) {
+        let request = createRequest(session: session, method: "GET", path: "/v1/users/\(userId ?? session.userId)/data_sets", queryItems: filter?.queryItems)
+        performRequest(request, completion: completion)
+    }
+
+    /// Create a data set for the specified user id. If no user id is specified, then the session user id is used.
+    ///
+    /// - Parameters:
+    ///   - dataSet: The data set to create.
+    ///   - userId: The user id for which to create the data set. If no user id is specified, then the session user id is used.
+    ///   - session: The Tidepool API session to use.
+    ///   - completion: The completion function to invoke with any error.
+    public func createDataSet(_ dataSet: TDataSet, userId: String? = nil, session: TSession, completion: @escaping (Result<TDataSet, TError>) -> Void) {
+        let request = createRequest(session: session, method: "POST", path: "/v1/users/\(userId ?? session.userId)/data_sets", body: dataSet)
+        performRequest(request) { (result: DecodableResult<LegacyResponse.Success<TDataSet>>) -> Void in
+            switch result {
+            case .failure(let error):
+                completion(.failure(error))
+            case .success(let legacyResponse):
+                completion(.success(legacyResponse.data))
+            }
+        }
+    }
+
+    // MARK: - Datum
+
+    public typealias DataResult = Result<([TDatum], [Int: [String:Any]]), TError>
+
+    /// List the data for the specified user id. If no user id is specified, then the session user id is used. A filter can
+    /// be specified to reduce the data returned.
+    ///
+    /// - Parameters:
+    ///   - filter: The filter to use when requesting the data.
+    ///   - userId: The user id for which to get the data. If no user id is specified, then the session user id is used.
+    ///   - session: The Tidepool API session to use.
+    ///   - completion: The completion function to invoke with any error.
+    public func listData(filter: TDatum.Filter? = nil, userId: String? = nil, session: TSession, completion: @escaping (DataResult) -> Void) {
+        let request = createRequest(session: session, method: "GET", path: "/data/\(userId ?? session.userId)", queryItems: filter?.queryItems)
+        performRequest(request) { (result: DecodableResult<DataResponse>) -> Void in
+            switch result {
+            case .failure(let error):
+                completion(.failure(error))
+            case .success(let data):
+                completion(.success((data.data, data.malformed)))
+            }
+        }
+    }
+
+    /// Create data for the specified user id. If no user id is specified, then the session user id is used.
+    ///
+    /// - Parameters:
+    ///   - data: The data to create.
+    ///   - userId: The user id for which to create the data. If no user id is specified, then the session user id is used.
+    ///   - session: The Tidepool API session to use.
+    ///   - completion: The completion function to invoke with any error.
+    public func createData(_ data: [TDatum], dataSetId: String, session: TSession, completion: @escaping (TError?) -> Void) {
+        let request = createRequest(session: session, method: "POST", path: "/v1/data_sets/\(dataSetId)/data", body: data)
+        performRequest(request) { (result: DecodableResult<LegacyResponse.Success<DataResponse>>) -> Void in
+            switch result {
+            case .failure(let error):
+                if case .requestMalformed(let response, let data) = error {
+                    if let data = data {
+                        if let legacyResponse = try? JSONDecoder.tidepool.decode(LegacyResponse.Failure.self, from: data) {
+                            completion(.requestMalformedJSON(response, data, legacyResponse.errors))
+                            return
+                        } else if let error = try? JSONDecoder.tidepool.decode(TError.Detail.self, from: data) {
+                            completion(.requestMalformedJSON(response, data, [error]))
+                            return
+                        }
+                    }
+                }
+                completion(error)
+            case .success:
+                completion(nil)
+            }
+        }
+    }
+
+    // MARK: - Internal - Create Request
+
+    private func createRequest<E>(session: TSession, method: String, path: String, body: E) -> URLRequest? where E: Encodable {
+        var request = createRequest(session: session, method: method, path: path)
+        request?.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
+        do {
+            request?.httpBody = try JSONEncoder.tidepool.encode(body)
+        } catch let error {
+            TSharedLogging.error("Failure encoding request body [\(error)]")
+            return nil
         }
         return request
     }
 
-    private func createRequest(environment: TEnvironment, method: String, path: String, queryItems: [URLQueryItem]? = nil) -> URLRequest {
-        var request = URLRequest(url: environment.url(path: path, queryItems: queryItems))
+    private func createRequest(session: TSession, method: String, path: String, queryItems: [URLQueryItem]? = nil) -> URLRequest? {
+        var request = createRequest(environment: session.environment, method: method, path: path, queryItems: queryItems)
+        request?.setValue(session.authenticationToken, forHTTPHeaderField: "X-Tidepool-Session-Token")
+        if let trace = session.trace {
+            request?.setValue(trace, forHTTPHeaderField: "X-Tidepool-Trace-Session")
+        }
+        return request
+    }
+
+    private func createRequest(environment: TEnvironment, method: String, path: String, queryItems: [URLQueryItem]? = nil) -> URLRequest? {
+        guard let url = environment.url(path: path, queryItems: queryItems) else {
+            TSharedLogging.error("Failure creating request URL [environment='\(environment)'; path='\(path)'; queryItems=\(String(describing: queryItems))")
+            return nil
+        }
+        var request = URLRequest(url: url)
         request.httpMethod = method
         return request
     }
 
-    private func performRequest(_ request: URLRequest, completion: @escaping (TError?) -> Void) {
+    // MARK: - Internal - Perform Request
+
+    private typealias DecodableResult<D> = Result<D, TError> where D: Decodable
+
+    private func performRequest<D>(_ request: URLRequest?, completion: @escaping (DecodableResult<D>) -> Void) where D: Decodable {
+        performRequest(request) { (result: DecodableHTTPResult<D>) -> Void in
+            switch result {
+            case .failure(let error):
+                completion(.failure(error))
+            case .success(_, _, let decoded):
+                completion(.success(decoded))
+            }
+        }
+    }
+
+    private typealias DecodableHTTPResult<D> = Result<(HTTPURLResponse, Data, D), TError> where D: Decodable
+
+    private func performRequest<D>(_ request: URLRequest?, completion: @escaping (DecodableHTTPResult<D>) -> Void) where D: Decodable {
+        performRequest(request) { (result: HTTPResult) -> Void in
+            switch result {
+            case .failure(let error):
+                completion(.failure(error))
+            case .success(let response, let data):
+                if let data = data {
+                    do {
+                        completion(.success((response, data, try JSONDecoder.tidepool.decode(D.self, from: data))))
+                    } catch let error {
+                        completion(.failure(.responseMalformedJSON(response, data, error)))
+                    }
+                } else {
+                    completion(.failure(.responseMissingJSON(response)))
+                }
+            }
+        }
+    }
+
+    private func performRequest(_ request: URLRequest?, completion: @escaping (TError?) -> Void) {
         performRequest(request) { (result: HTTPResult) -> Void in
             switch result {
             case .failure(let error):
                 completion(error)
-            case .success(_, _):
+            case .success:
                 completion(nil)
             }
         }
@@ -178,7 +331,12 @@ public class TAPI {
 
     private typealias HTTPResult = Result<(HTTPURLResponse, Data?), TError>
 
-    private func performRequest(_ request: URLRequest, completion: @escaping (HTTPResult) -> Void) {
+    private func performRequest(_ request: URLRequest?, completion: @escaping (HTTPResult) -> Void) {
+        guard let request = request else {
+            completion(.failure(.requestInvalid))
+            return
+        }
+
         let task = urlSession.dataTask(with: request) { (data, response, error) in
             if let error = error {
                 completion(.failure(.network(error)))

--- a/TidepoolKit/TAPI.swift
+++ b/TidepoolKit/TAPI.swift
@@ -83,7 +83,7 @@ public class TAPI {
     ///   - completion: The completion function to invoke with the newly created session or an error.
     public func login(environment: TEnvironment, email: String, password: String, completion: @escaping (Result<TSession, TError>) -> Void) {
         var request = createRequest(environment: environment, method: "POST", path: "/auth/login")
-        request?.setValue(basicAuthorizationFromCredentials(email: email, password: password), forHTTPHeaderField: "Authorization")
+        request?.setValue(basicAuthorizationFromCredentials(email: email, password: password), forHTTPHeaderField: HTTPHeaderField.authorization.rawValue)
         performRequest(request) { (result: DecodableHTTPResult<LoginResponse>) -> Void in
             switch result {
             case .failure(let error):
@@ -253,7 +253,7 @@ public class TAPI {
 
     private func createRequest<E>(session: TSession, method: String, path: String, body: E) -> URLRequest? where E: Encodable {
         var request = createRequest(session: session, method: method, path: path)
-        request?.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
+        request?.setValue("application/json; charset=utf-8", forHTTPHeaderField: HTTPHeaderField.contentType.rawValue)
         do {
             request?.httpBody = try JSONEncoder.tidepool.encode(body)
         } catch let error {
@@ -265,9 +265,9 @@ public class TAPI {
 
     private func createRequest(session: TSession, method: String, path: String, queryItems: [URLQueryItem]? = nil) -> URLRequest? {
         var request = createRequest(environment: session.environment, method: method, path: path, queryItems: queryItems)
-        request?.setValue(session.authenticationToken, forHTTPHeaderField: "X-Tidepool-Session-Token")
+        request?.setValue(session.authenticationToken, forHTTPHeaderField: HTTPHeaderField.tidepoolSessionToken.rawValue)
         if let trace = session.trace {
-            request?.setValue(trace, forHTTPHeaderField: "X-Tidepool-Trace-Session")
+            request?.setValue(trace, forHTTPHeaderField: HTTPHeaderField.tidepoolTraceSession.rawValue)
         }
         return request
     }
@@ -403,4 +403,11 @@ public class TAPI {
     private static let DNSSRVRecordsDomainName = "environments-srv.tidepool.org"
 
     private static let DNSSRVRecordsImplicit = [DNSSRVRecord(priority: UInt16.min, weight: UInt16.max, host: "app.tidepool.org", port: 443)]
+
+    private enum HTTPHeaderField: String {
+        case authorization = "Authorization"
+        case contentType = "Content-Type"
+        case tidepoolSessionToken = "X-Tidepool-Session-Token"
+        case tidepoolTraceSession = "X-Tidepool-Trace-Session"
+    }
 }

--- a/TidepoolKit/TEnvironment.swift
+++ b/TidepoolKit/TEnvironment.swift
@@ -12,8 +12,7 @@ import Foundation
 /// via DNS SRV record lookup.
 ///
 /// Network requests will use HTTPS only if port is 443. Otherwise, HTTP will be used.
-public struct TEnvironment: RawRepresentable {
-    public typealias RawValue = [String: Any]
+public struct TEnvironment: Codable, Equatable {
 
     /// The host for the environment. For example, api.tidepool.org.
     public let host: String
@@ -26,24 +25,7 @@ public struct TEnvironment: RawRepresentable {
         self.port = port
     }
 
-    public init?(rawValue: RawValue) {
-        guard let host = rawValue["host"] as? String,
-            let port = rawValue["port"] as? UInt16 else
-        {
-            return nil
-        }
-        self.host = host
-        self.port = port
-    }
-
-    public var rawValue: RawValue {
-        var rawValue: RawValue = [:]
-        rawValue["host"] = host
-        rawValue["port"] = port
-        return rawValue
-    }
-
-    public func url(path: String = "", queryItems: [URLQueryItem]? = nil) -> URL {
+    public func url(path: String = "/", queryItems: [URLQueryItem]? = nil) -> URL? {
         var components = URLComponents()
         components.host = host
         switch port {
@@ -55,9 +37,9 @@ public struct TEnvironment: RawRepresentable {
                 components.scheme = "http"
                 components.port = Int(port)
         }
-        components.path = path
+        components.path = path.hasPrefix("/") ? path : "/\(path)"
         components.queryItems = queryItems
-        return components.url!
+        return components.url
     }
 }
 

--- a/TidepoolKit/TError.swift
+++ b/TidepoolKit/TError.swift
@@ -14,8 +14,14 @@ public enum TError: Error {
     /// A general network error not covered by another more specific error. May include a more detailed OS-level error.
     case network(Error?)
 
+    /// The request was invalid and not sent.
+    case requestInvalid
+
     /// The server responded that the request was bad or malformed. Equivalent to HTTP status code 400.
     case requestMalformed(HTTPURLResponse, Data?)
+
+    /// The server responded that the request was bad or malformed with details. Equivalent to HTTP status code 400.
+    case requestMalformedJSON(HTTPURLResponse, Data, [Detail])
 
     /// The server responded that the request was not authenticated. Equivalent to HTTP status code 401.
     case requestNotAuthenticated(HTTPURLResponse, Data?)
@@ -45,7 +51,7 @@ public enum TError: Error {
     case responseMissingJSON(HTTPURLResponse)
 
     /// The server response did not include valid JSON in the body.
-    case responseMalformedJSON(HTTPURLResponse, Data)
+    case responseMalformedJSON(HTTPURLResponse, Data, Error)
 
     /// The server response included valid, but unexpected, JSON in the body.
     case responseUnexpectedJSON(HTTPURLResponse, Data)
@@ -53,36 +59,55 @@ public enum TError: Error {
     /// The server response included malformed data.
     case responseMalformedData(HTTPURLResponse, Data)
 
-    /// The default localized description of the error.
-    public var localizedDescription: String {
+    public struct Detail: Codable, Equatable {
+        public var code: String
+        public var title: String
+        public var detail: String
+        public var status: Int?
+        public var source: Source?
+        public var meta: TDictionary?
+
+        public struct Source: Codable, Equatable {
+            public var parameter: String?
+            public var pointer: String?
+        }
+    }
+}
+
+extension TError: LocalizedError {
+    public var errorDescription: String? {
         switch self {
-        case .network(_):
+        case .network:
             return NSLocalizedString("A network error occurred.", comment: "The default localized description of the network error")
-        case .requestMalformed(_):
+        case .requestInvalid:
+            return NSLocalizedString("The request was invalid.", comment: "The default localized description of the request invalid error")
+        case .requestMalformed:
             return NSLocalizedString("The request was invalid.", comment: "The default localized description of the request malformed error")
-        case .requestNotAuthenticated(_):
+        case .requestMalformedJSON:
+            return NSLocalizedString("The request was invalid.", comment: "The default localized description of the request malformed JSON error")
+        case .requestNotAuthenticated:
             return NSLocalizedString("The request was not authenticated.", comment: "The default localized description of the request not authenticated error")
-        case .requestNotAuthorized(_):
+        case .requestNotAuthorized:
             return NSLocalizedString("The request was not authorized.", comment: "The default localized description of the request not authorized error")
-        case .requestEmailNotVerified(_):
+        case .requestEmailNotVerified:
             return NSLocalizedString("The email is not verified.", comment: "The default localized description of the request email not verified error")
-        case .requestTermsOfServiceNotAccepted(_):
+        case .requestTermsOfServiceNotAccepted:
             return NSLocalizedString("The Terms of Service are not accepted.", comment: "The default localized description of the request terms of service not accepted error")
-        case .requestResourceNotFound(_):
+        case .requestResourceNotFound:
             return NSLocalizedString("The requested resource was not found.", comment: "The default localized description of the request resource not found error")
-        case .responseUnexpected(_, _):
+        case .responseUnexpected:
             return NSLocalizedString("The request returned an unexpected response.", comment: "The default localized description of the response unexpected error")
-        case .responseUnexpectedStatusCode(_, _):
+        case .responseUnexpectedStatusCode:
             return NSLocalizedString("The request returned an unexpected response status code.", comment: "The default localized description of the response unexpected status code error")
-        case .responseNotAuthenticated(_, _):
+        case .responseNotAuthenticated:
             return NSLocalizedString("The request returned an unauthenticated response.", comment: "The default localized description of the response not authenticated error")
-        case .responseMissingJSON(_):
+        case .responseMissingJSON:
             return NSLocalizedString("The request returned an empty JSON response.", comment: "The default localized description of the response missing JSON error")
-        case .responseMalformedJSON(_):
+        case .responseMalformedJSON:
             return NSLocalizedString("The request returned an invalid JSON response.", comment: "The default localized description of the response malformed JSON error")
-        case .responseUnexpectedJSON(_):
+        case .responseUnexpectedJSON:
             return NSLocalizedString("The request returned an unexpected JSON response.", comment: "The default localized description of the response unexpected JSON error")
-        case .responseMalformedData(_):
+        case .responseMalformedData:
             return NSLocalizedString("The request returned an invalid response.", comment: "The default localized description of the response malformed data error")
         }
     }

--- a/TidepoolKit/TSession.swift
+++ b/TidepoolKit/TSession.swift
@@ -8,9 +8,8 @@
 
 import Foundation
 
-/// Representation of a Tidepool API session, including the environment, an authentication token, and a user ID.
-public struct TSession: RawRepresentable {
-    public typealias RawValue = [String: Any]
+/// Representation of a Tidepool API session, including the environment, an authentication token, and a user id.
+public struct TSession: Codable, Equatable {
 
     // The environment used for authentication and for any future API network requests.
     public let environment: TEnvironment
@@ -18,40 +17,17 @@ public struct TSession: RawRepresentable {
     // The authentication token returned via authentication and for use with any future API network requests.
     public let authenticationToken: String
 
-    // The user ID associated with the authentication token required by some API network requests.
-    public let userID: String
+    // The user id associated with the authentication token required by some API network requests.
+    public let userId: String
 
     // The value of the optional X-Tidepool-Trace-Session header added to any future API network requests. The default UUID string
     // is usually sufficient, but can be changed or removed.
     public var trace: String?
     
-    public init(environment: TEnvironment, authenticationToken: String, userID: String, trace: String? = UUID().uuidString) {
+    public init(environment: TEnvironment, authenticationToken: String, userId: String, trace: String? = UUID().uuidString) {
         self.environment = environment
         self.authenticationToken = authenticationToken
-        self.userID = userID
+        self.userId = userId
         self.trace = trace
-    }
-
-    public init?(rawValue: RawValue) {
-        guard let environmentRawValue = rawValue["environment"] as? TEnvironment.RawValue,
-            let environment = TEnvironment(rawValue: environmentRawValue),
-            let authenticationToken = rawValue["authenticationToken"] as? String,
-            let userID = rawValue["userID"] as? String else
-        {
-            return nil
-        }
-        self.environment = environment
-        self.authenticationToken = authenticationToken
-        self.userID = userID
-        self.trace = rawValue["trace"] as? String
-    }
-    
-    public var rawValue: RawValue {
-        var rawValue: RawValue = [:]
-        rawValue["environment"] = environment.rawValue
-        rawValue["authenticationToken"] = authenticationToken
-        rawValue["userID"] = userID
-        rawValue["trace"] = trace
-        return rawValue
     }
 }

--- a/TidepoolKitTests/Extensions/JSONDecoderTests.swift
+++ b/TidepoolKitTests/Extensions/JSONDecoderTests.swift
@@ -1,0 +1,23 @@
+//
+//  JSONDecoderTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 3/3/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TJSONDecoderTests: XCTestCase {
+    func testTidepoolJSONDecoder() {
+        func assertDateDecoding() throws {
+            let data = "\"\(Date.testJSONString)\"".data(using: .utf8)
+            XCTAssertNotNil(data)
+            if let data = data {
+                XCTAssertEqual(try JSONDecoder.tidepool.decode(Date.self, from: data), Date.test)
+            }
+        }
+        XCTAssertNoThrow(try assertDateDecoding())
+    }
+}

--- a/TidepoolKitTests/Extensions/JSONEncoderTests.swift
+++ b/TidepoolKitTests/Extensions/JSONEncoderTests.swift
@@ -1,0 +1,20 @@
+//
+//  JSONEncoderTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 3/3/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TJSONEncoderTests: XCTestCase {
+    func testTidepoolJSONEncoder() {
+        func assertDateEncoding() throws {
+            let data = try JSONEncoder.tidepool.encode(Date.test)
+            XCTAssertEqual(String(data: data, encoding: .utf8), "\"\(Date.testJSONString)\"")
+        }
+        XCTAssertNoThrow(try assertDateEncoding())
+    }
+}

--- a/TidepoolKitTests/Internal/Extensions/Date.swift
+++ b/TidepoolKitTests/Internal/Extensions/Date.swift
@@ -1,0 +1,14 @@
+//
+//  Date.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 11/6/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+extension Date {
+    static let test = Date(timeIntervalSinceReferenceDate: 123456.789)
+    static let testJSONString = "2001-01-02T10:17:36.789Z"
+}

--- a/TidepoolKitTests/Internal/Extensions/XCTest.swift
+++ b/TidepoolKitTests/Internal/Extensions/XCTest.swift
@@ -1,0 +1,72 @@
+//
+//  XCTest.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 3/2/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+public func XCTAssertCodableAsJSON<T>(_ codable: @autoclosure () -> T, _ jsonObject: @autoclosure () -> Any, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) where T: Codable, T: Equatable {
+    let codable = codable()
+    let jsonObject = jsonObject()
+    let message = message()
+
+    func assertCodableAsJSON() throws {
+        let jsonData = try JSONSerialization.data(withJSONObject: jsonObject, options: [.sortedKeys, .withoutEscapingSlashes])
+        let jsonString = String(data: jsonData, encoding: .utf8)
+        XCTAssertNotNil(jsonString, message, file: file, line: line)
+        if let jsonString = jsonString {
+            XCTAssertCodableAsJSON(codable, jsonString, message, file: file, line: line)
+        }
+    }
+
+    XCTAssertNoThrow(try assertCodableAsJSON(), message, file: file, line: line)
+}
+
+public func XCTAssertCodableAsJSON<T>(_ codable: @autoclosure () -> T, _ jsonString: @autoclosure () -> String, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) where T: Codable, T: Equatable {
+    let codable = codable()
+    let jsonString = jsonString()
+    let message = message()
+
+    func assertEncodableAsJSON() throws {
+        let codableData = try JSONEncoder.tidepool.encode(codable)
+        let codableString = String(data: codableData, encoding: .utf8)
+        XCTAssertNotNil(codableString, message, file: file, line: line)
+        if let codableString = codableString {
+            XCTAssertEqual(codableString, jsonString, message, file: file, line: line)
+        }
+    }
+
+    func assertDecodableAsJSON() throws {
+        let jsonData = jsonString.data(using: .utf8)
+        XCTAssertNotNil(jsonData, message, file: file, line: line)
+        if let jsonData = jsonData {
+            let jsonCodable = try JSONDecoder.tidepool.decode(T.self, from: jsonData)
+            XCTAssertEqual(jsonCodable, codable, message, file: file, line: line)
+        }
+    }
+
+    XCTAssertNoThrow(try assertEncodableAsJSON(), message, file: file, line: line)
+    XCTAssertNoThrow(try assertDecodableAsJSON(), message, file: file, line: line)
+}
+
+public class XCTestExpectationWithResult<Success, Failure>: XCTestExpectation where Failure: Error {
+    var result: Result<Success, Failure>?
+
+    func fulfill(_ result: Result<Success, Failure>) {
+        self.result = result
+        super.fulfill()
+    }
+}
+
+public class XCTestExpectationWithError: XCTestExpectation {
+    var error: TError?
+
+    func fulfill(_ error: TError?) {
+        self.error = error
+        super.fulfill()
+    }
+}

--- a/TidepoolKitTests/Internal/URLProtocolMock.swift
+++ b/TidepoolKitTests/Internal/URLProtocolMock.swift
@@ -1,0 +1,118 @@
+//
+//  URLProtocolMock.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 3/5/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+class URLProtocolMock: URLProtocol {
+    static var validator: Validator?
+    static var error: Error?
+    static var success: Success?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.validator?.validate(request: request)
+
+        if let error = Self.error {
+            client?.urlProtocol(self, didFailWithError: error)
+        } else if let url = request.url, let success = Self.success, let urlResponse = success.response(for: url) {
+            client?.urlProtocol(self, didReceive: urlResponse, cacheStoragePolicy: .notAllowed)
+            if let body = success.body {
+                client?.urlProtocol(self, didLoad: body)
+            }
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    struct Validator {
+        let url: URL
+        let method: String
+        let headers: [String: String]?
+        let body: Data?
+
+        init(url: String, method: String, headers: [String: String]? = nil, body: Data? = nil) {
+            self.url = URL(string: url)!
+            self.method = method
+            self.headers = headers
+            self.body = body
+        }
+
+        init<E>(url: String, method: String, headers: [String: String]? = nil, body: E) where E: Encodable {
+            self.init(url: url, method: method, headers: headers, body: try? JSONEncoder.tidepool.encode(body))
+        }
+
+        func validate(request: URLRequest) {
+            XCTAssertEqual(request.url, url)
+            XCTAssertEqual(request.httpMethod, method)
+            if let headers = headers {
+                XCTAssertNotNil(request.allHTTPHeaderFields)
+                if let allHTTPHeaderFields = request.allHTTPHeaderFields {
+                    for (key, value) in headers {
+                        XCTAssertEqual(allHTTPHeaderFields[key], value)
+                    }
+                }
+            }
+            if let body = body {
+                if let httpBodyStream = request.httpBodyStream {
+                    XCTAssertEqual(Data(from: httpBodyStream), body)
+                } else {
+                    XCTAssertEqual(request.httpBody, body)
+                }
+            }
+        }
+    }
+
+    struct Success {
+        var statusCode: Int
+        var headers: [String: String]?
+        var body: Data?
+
+        init(statusCode: Int, headers: [String: String]? = nil, body: Data? = nil) {
+            self.statusCode = statusCode
+            self.headers = headers
+            self.body = body
+        }
+
+        init<E>(statusCode: Int, headers: [String: String]? = nil, body: E) where E: Encodable {
+            self.init(statusCode: statusCode, headers: headers, body: try? JSONEncoder.tidepool.encode(body))
+        }
+
+        mutating func set<E>(body: E) where E: Encodable {
+            self.body = try? JSONEncoder.tidepool.encode(body)
+        }
+
+        func response(for url: URL) -> URLResponse? {
+            return HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: "HTTP/1.1", headerFields: headers)
+        }
+    }
+}
+
+fileprivate extension Data {
+    private static let bufferSize = 2048
+
+    init?(from inputStream: InputStream) {
+        self.init()
+
+        inputStream.open()
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: Self.bufferSize)
+        while inputStream.hasBytesAvailable {
+            let bytesRead = inputStream.read(buffer, maxLength: Self.bufferSize)
+            guard bytesRead >= 0 else {
+                return nil
+            }
+            self.append(buffer, count: bytesRead)
+        }
+        buffer.deallocate()
+        inputStream.close()
+    }
+}

--- a/TidepoolKitTests/Model/Datum/TCBGDatumTests.swift
+++ b/TidepoolKitTests/Model/Datum/TCBGDatumTests.swift
@@ -1,0 +1,36 @@
+//
+//  TCBGDatumTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 11/6/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TCBGDatumTests: XCTestCase {
+    static let cbg = TCBGDatum(time: Date.test, value: 1.23, units: .milligramsPerDeciliter)
+    static let cbgJSONDictionary: [String: Any] = [
+        "type": "cbg",
+        "time": Date.testJSONString,
+        "value": 1.23,
+        "units": "mg/dL"
+    ]
+    
+    func testInitializer() {
+        let cbg = TCBGDatumTests.cbg
+        XCTAssertEqual(cbg.value, 1.23)
+        XCTAssertEqual(cbg.units, .milligramsPerDeciliter)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TCBGDatumTests.cbg, TCBGDatumTests.cbgJSONDictionary)
+    }
+}
+
+extension TCBGDatum {
+    func isEqual(to other: TCBGDatum) -> Bool {
+        return super.isEqual(to: other) && self.value == other.value && self.units == other.units
+    }
+}

--- a/TidepoolKitTests/Model/Datum/TDatumTests.swift
+++ b/TidepoolKitTests/Model/Datum/TDatumTests.swift
@@ -1,0 +1,165 @@
+//
+//  TDatumTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 11/6/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TDatumTests: XCTestCase {
+    static let datum = TDatum(.cbg,
+                              time: Date.test,
+                              annotations: [TDictionary(["a": "b", "c": 0]), TDictionary(["alpha": "bravo"])],
+                              associations: [TAssociationTests.association, TAssociationTests.association],
+                              clockDriftOffset: 1234,
+                              conversionOffset: 2345,
+                              dataSetId: "3456789012",
+                              deviceId: "TestDevice",
+                              deviceTime: "2019-01-02T03:04:05",
+                              id: "2345678901",
+                              location: TLocationTests.location,
+                              notes: ["One", "Two"],
+                              origin: TOriginTests.origin,
+                              payload: TDictionary(["foo": "bar"]),
+                              tags: ["Fast", "Slow"],
+                              timezone: "America/Los_Angeles",
+                              timezoneOffset: 25200)
+    static let datumJSONDictionary: [String: Any] = [
+        "type": "water",
+        "time": Date.testJSONString,
+        "annotations": [["a": "b", "c": 0], ["alpha": "bravo"]],
+        "associations": [TAssociationTests.assocationJSONDictionary, TAssociationTests.assocationJSONDictionary],
+        "clockDriftOffset": 1234,
+        "conversionOffset": 2345,
+        "uploadId": "3456789012",
+        "deviceId": "TestDevice",
+        "deviceTime": "2019-01-02T03:04:05",
+        "id": "2345678901",
+        "location": TLocationTests.locationJSONDictionary,
+        "notes": ["One", "Two"],
+        "origin": TOriginTests.originJSONDictionary,
+        "payload": ["foo": "bar"],
+        "tags": ["Fast", "Slow"],
+        "timezone": "America/Los_Angeles",
+        "timezoneOffset": 420
+    ]
+    
+    func testInitializer() {
+        let datum = TDatumTests.datum
+        XCTAssertEqual(datum.type, .cbg)
+        XCTAssertEqual(datum.time, Date.test)
+        XCTAssertEqual(datum.annotations, [TDictionary(["a": "b", "c": 0]), TDictionary(["alpha": "bravo"])])
+        XCTAssertEqual(datum.associations, [TAssociationTests.association, TAssociationTests.association])
+        XCTAssertEqual(datum.clockDriftOffset, 1234)
+        XCTAssertEqual(datum.conversionOffset, 2345)
+        XCTAssertEqual(datum.dataSetId, "3456789012")
+        XCTAssertEqual(datum.deviceId, "TestDevice")
+        XCTAssertEqual(datum.deviceTime, "2019-01-02T03:04:05")
+        XCTAssertEqual(datum.id, "2345678901")
+        XCTAssertEqual(datum.location, TLocationTests.location)
+        XCTAssertEqual(datum.notes, ["One", "Two"])
+        XCTAssertEqual(datum.origin, TOriginTests.origin)
+        XCTAssertEqual(datum.payload, TDictionary(["foo": "bar"]))
+        XCTAssertEqual(datum.tags, ["Fast", "Slow"])
+        XCTAssertEqual(datum.timezone, "America/Los_Angeles")
+        XCTAssertEqual(datum.timezoneOffset, 25200)
+    }
+}
+
+class TDatumDatumTypeTests: XCTestCase {
+    func testDatumType() {
+        XCTAssertEqual(TDatum.DatumType.basal.rawValue, "basal")
+        XCTAssertEqual(TDatum.DatumType.bloodKetone.rawValue, "bloodKetone")
+        XCTAssertEqual(TDatum.DatumType.bolus.rawValue, "bolus")
+        XCTAssertEqual(TDatum.DatumType.calculator.rawValue, "wizard")
+        XCTAssertEqual(TDatum.DatumType.cbg.rawValue, "cbg")
+        XCTAssertEqual(TDatum.DatumType.cgmSettings.rawValue, "cgmSettings")
+        XCTAssertEqual(TDatum.DatumType.deviceEvent.rawValue, "deviceEvent")
+        XCTAssertEqual(TDatum.DatumType.food.rawValue, "food")
+        XCTAssertEqual(TDatum.DatumType.insulin.rawValue, "insulin")
+        XCTAssertEqual(TDatum.DatumType.physicalActivity.rawValue, "physicalActivity")
+        XCTAssertEqual(TDatum.DatumType.pumpSettings.rawValue, "pumpSettings")
+        XCTAssertEqual(TDatum.DatumType.reportedState.rawValue, "reportedState")
+        XCTAssertEqual(TDatum.DatumType.smbg.rawValue, "smbg")
+        XCTAssertEqual(TDatum.DatumType.upload.rawValue, "upload")
+        XCTAssertEqual(TDatum.DatumType.water.rawValue, "water")
+    }
+}
+
+class TDatumFilterTests: XCTestCase {
+    static let filter = TDatum.Filter(startDate: Date.test,
+                                      endDate: Date.test,
+                                      dataSetId: "1234567890",
+                                      deviceId: "2345678901",
+                                      carelink: true,
+                                      dexcom: false,
+                                      medtronic: true,
+                                      latest: false,
+                                      types: ["cgm", "bolus"],
+                                      subTypes: ["normal", "extended"])
+
+    func testInitializer() {
+        let filter = TDatumFilterTests.filter
+        XCTAssertEqual(filter.startDate, Date.test)
+        XCTAssertEqual(filter.endDate, Date.test)
+        XCTAssertEqual(filter.dataSetId, "1234567890")
+        XCTAssertEqual(filter.deviceId, "2345678901")
+        XCTAssertEqual(filter.carelink, true)
+        XCTAssertEqual(filter.dexcom, false)
+        XCTAssertEqual(filter.medtronic, true)
+        XCTAssertEqual(filter.latest, false)
+        XCTAssertEqual(filter.types, ["cgm", "bolus"])
+        XCTAssertEqual(filter.subTypes, ["normal", "extended"])
+    }
+
+    func testQueryItems() {
+        XCTAssertEqual(TDatumFilterTests.filter.queryItems, [URLQueryItem(name: "startDate", value: Date.testJSONString),
+                                                             URLQueryItem(name: "endDate", value: Date.testJSONString),
+                                                             URLQueryItem(name: "uploadId", value: "1234567890"),
+                                                             URLQueryItem(name: "deviceId", value: "2345678901"),
+                                                             URLQueryItem(name: "carelink", value: "true"),
+                                                             URLQueryItem(name: "dexcom", value: "false"),
+                                                             URLQueryItem(name: "medtronic", value: "true"),
+                                                             URLQueryItem(name: "latest", value: "false"),
+                                                             URLQueryItem(name: "types", value: "cgm,bolus"),
+                                                             URLQueryItem(name: "subTypes", value: "normal,extended")])
+    }
+}
+
+extension TDatum: Equatable {
+
+    // NOTE: Yes, a bit of a hack, but it is explicitly only used for tests.
+    public static func == (lhs: TDatum, rhs: TDatum) -> Bool {
+        switch (lhs, rhs) {
+        case let (lhs as TCBGDatum, rhs as TCBGDatum):
+            return lhs.isEqual(to: rhs)
+        case let (lhs as TFoodDatum, rhs as TFoodDatum):
+            return lhs.isEqual(to: rhs)
+        default:
+            return false
+        }
+    }
+    
+    func isEqual(to other: TDatum) -> Bool {
+        return self.type == other.type &&
+            self.time == other.time &&
+            self.annotations == other.annotations &&
+            self.associations == other.associations &&
+            self.clockDriftOffset == other.clockDriftOffset &&
+            self.conversionOffset == other.conversionOffset &&
+            self.dataSetId == other.dataSetId &&
+            self.deviceId == other.deviceId &&
+            self.deviceTime == other.deviceTime &&
+            self.id == other.id &&
+            self.location == other.location &&
+            self.notes == other.notes &&
+            self.origin == other.origin &&
+            self.payload == other.payload &&
+            self.tags == other.tags &&
+            self.timezone == other.timezone &&
+            self.timezoneOffset == other.timezoneOffset
+    }
+}

--- a/TidepoolKitTests/Model/Datum/TFoodDatumTests.swift
+++ b/TidepoolKitTests/Model/Datum/TFoodDatumTests.swift
@@ -1,0 +1,253 @@
+//
+//  TFoodDatumTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 11/7/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TFoodDatumTests: XCTestCase {
+    static let food = TFoodDatum(time: Date.test,
+                                 name: "Amazing",
+                                 amount: TFoodDatumAmountTests.amount,
+                                 brand: "Foodie",
+                                 code: "XYZ",
+                                 meal: .other,
+                                 mealOther: "midnightSnack",
+                                 nutrition: TFoodDatumNutritionTests.nutrition,
+                                 ingredients: [TFoodDatumIngredientTests.ingredient])
+    static let foodJSONDictionary: [String: Any] = [
+        "type": "food",
+        "time": Date.testJSONString,
+        "name": "Amazing",
+        "amount": TFoodDatumAmountTests.amountJSONDictionary,
+        "brand": "Foodie",
+        "code": "XYZ",
+        "meal": "other",
+        "mealOther": "midnightSnack",
+        "nutrition": TFoodDatumNutritionTests.nutritionJSONDictionary,
+        "ingredients": [TFoodDatumIngredientTests.ingredientJSONDictionary]
+    ]
+    
+    func testInitializer() {
+        let food = TFoodDatumTests.food
+        XCTAssertEqual(food.name, "Amazing")
+        XCTAssertEqual(food.amount, TFoodDatumAmountTests.amount)
+        XCTAssertEqual(food.brand, "Foodie")
+        XCTAssertEqual(food.code, "XYZ")
+        XCTAssertEqual(food.meal, .other)
+        XCTAssertEqual(food.mealOther, "midnightSnack")
+        XCTAssertEqual(food.nutrition, TFoodDatumNutritionTests.nutrition)
+        XCTAssertEqual(food.ingredients, [TFoodDatumIngredientTests.ingredient])
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TFoodDatumTests.food, TFoodDatumTests.foodJSONDictionary)
+    }
+}
+
+class TFoodDatumMealTests: XCTestCase {
+    func testMeal() {
+        XCTAssertEqual(TFoodDatum.Meal.breakfast.rawValue, "breakfast")
+        XCTAssertEqual(TFoodDatum.Meal.lunch.rawValue, "lunch")
+        XCTAssertEqual(TFoodDatum.Meal.dinner.rawValue, "dinner")
+        XCTAssertEqual(TFoodDatum.Meal.snack.rawValue, "snack")
+        XCTAssertEqual(TFoodDatum.Meal.other.rawValue, "other")
+    }
+}
+
+class TFoodDatumAmountTests: XCTestCase {
+    static let amount = TFoodDatum.Amount(1.23, "cups")
+    static let amountJSONDictionary: [String: Any] = [
+        "value": 1.23,
+        "units": "cups"
+    ]
+    
+    func testInitializer() {
+        let amount = TFoodDatumAmountTests.amount
+        XCTAssertEqual(amount.value, 1.23)
+        XCTAssertEqual(amount.units, "cups")
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TFoodDatumAmountTests.amount, TFoodDatumAmountTests.amountJSONDictionary)
+    }
+}
+
+class TFoodDatumNutritionTests: XCTestCase {
+    static let nutrition = TFoodDatum.Nutrition(carbohydrate: TFoodDatumNutritionCarbohydrateTests.carbohydrate,
+                                                fat: TFoodDatumNutritionFatTests.fat,
+                                                protein: TFoodDatumNutritionProteinTests.protein,
+                                                energy: TFoodDatumNutritionEnergyTests.energy)
+    static let nutritionJSONDictionary: [String: Any] = [
+        "carbohydrate": TFoodDatumNutritionCarbohydrateTests.carbohydrateJSONDictionary,
+        "fat": TFoodDatumNutritionFatTests.fatJSONDictionary,
+        "protein": TFoodDatumNutritionProteinTests.proteinJSONDictionary,
+        "energy": TFoodDatumNutritionEnergyTests.energyJSONDictionary
+    ]
+    
+    func testInitializer() {
+        let nutrition = TFoodDatumNutritionTests.nutrition
+        XCTAssertEqual(nutrition.carbohydrate, TFoodDatumNutritionCarbohydrateTests.carbohydrate)
+        XCTAssertEqual(nutrition.fat, TFoodDatumNutritionFatTests.fat)
+        XCTAssertEqual(nutrition.protein, TFoodDatumNutritionProteinTests.protein)
+        XCTAssertEqual(nutrition.energy, TFoodDatumNutritionEnergyTests.energy)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TFoodDatumNutritionTests.nutrition, TFoodDatumNutritionTests.nutritionJSONDictionary)
+    }
+}
+
+class TFoodDatumNutritionCarbohydrateTests: XCTestCase {
+    static let carbohydrate = TFoodDatum.Nutrition.Carbohydrate(net: 1.23, sugars: 2.34, dietaryFiber: 3.45, total: 4.56, units: .grams)
+    static let carbohydrateJSONDictionary: [String: Any] = [
+        "net": 1.23,
+        "sugars": 2.34,
+        "dietaryFiber": 3.45,
+        "total": 4.56,
+        "units": "grams"
+    ]
+    
+    func testInitializer() {
+        let carbohydrate = TFoodDatumNutritionCarbohydrateTests.carbohydrate
+        XCTAssertEqual(carbohydrate.net, 1.23)
+        XCTAssertEqual(carbohydrate.sugars, 2.34)
+        XCTAssertEqual(carbohydrate.dietaryFiber, 3.45)
+        XCTAssertEqual(carbohydrate.total, 4.56)
+        XCTAssertEqual(carbohydrate.units, .grams)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TFoodDatumNutritionCarbohydrateTests.carbohydrate, TFoodDatumNutritionCarbohydrateTests.carbohydrateJSONDictionary)
+    }
+}
+
+class TFoodDatumNutritionCarbohydrateUnitsTests: XCTestCase {
+    func testUnits() {
+        XCTAssertEqual(TFoodDatum.Nutrition.Carbohydrate.Units.grams.rawValue, "grams")
+    }
+}
+
+class TFoodDatumNutritionFatTests: XCTestCase {
+    static let fat = TFoodDatum.Nutrition.Fat(1.23, .grams)
+    static let fatJSONDictionary: [String: Any] = [
+        "total": 1.23,
+        "units": "grams"
+    ]
+    
+    func testInitializer() {
+        let fat = TFoodDatumNutritionFatTests.fat
+        XCTAssertEqual(fat.total, 1.23)
+        XCTAssertEqual(fat.units, .grams)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TFoodDatumNutritionFatTests.fat, TFoodDatumNutritionFatTests.fatJSONDictionary)
+    }
+}
+
+class TFoodDatumNutritionFatUnitsTests: XCTestCase {
+    func testUnits() {
+        XCTAssertEqual(TFoodDatum.Nutrition.Fat.Units.grams.rawValue, "grams")
+    }
+}
+
+class TFoodDatumNutritionProteinTests: XCTestCase {
+    static let protein = TFoodDatum.Nutrition.Protein(1.23, .grams)
+    static let proteinJSONDictionary: [String: Any] = [
+        "total": 1.23,
+        "units": "grams"
+    ]
+    
+    func testInitializer() {
+        let protein = TFoodDatumNutritionProteinTests.protein
+        XCTAssertEqual(protein.total, 1.23)
+        XCTAssertEqual(protein.units, .grams)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TFoodDatumNutritionProteinTests.protein, TFoodDatumNutritionProteinTests.proteinJSONDictionary)
+    }
+}
+
+class TFoodDatumNutritionProteinUnitsTests: XCTestCase {
+    func testUnits() {
+        XCTAssertEqual(TFoodDatum.Nutrition.Protein.Units.grams.rawValue, "grams")
+    }
+}
+
+class TFoodDatumNutritionEnergyTests: XCTestCase {
+    static let energy = TFoodDatum.Nutrition.Energy(1.23, .kilocalories)
+    static let energyJSONDictionary: [String: Any] = [
+        "value": 1.23,
+        "units": "kilocalories"
+    ]
+    
+    func testInitializer() {
+        let energy = TFoodDatumNutritionEnergyTests.energy
+        XCTAssertEqual(energy.value, 1.23)
+        XCTAssertEqual(energy.units, .kilocalories)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TFoodDatumNutritionEnergyTests.energy, TFoodDatumNutritionEnergyTests.energyJSONDictionary)
+    }
+}
+
+class TFoodDatumNutritionEnergyUnitsTests: XCTestCase {
+    func testUnits() {
+        XCTAssertEqual(TFoodDatum.Nutrition.Energy.Units.calories.rawValue, "calories")
+        XCTAssertEqual(TFoodDatum.Nutrition.Energy.Units.joules.rawValue, "joules")
+        XCTAssertEqual(TFoodDatum.Nutrition.Energy.Units.kilocalories.rawValue, "kilocalories")
+        XCTAssertEqual(TFoodDatum.Nutrition.Energy.Units.kilojoules.rawValue, "kilojoules")
+    }
+}
+
+class TFoodDatumIngredientTests: XCTestCase {
+    static let ingredient = TFoodDatum.Ingredient(name: "Stuff",
+                                                  amount: TFoodDatumAmountTests.amount,
+                                                  brand: "Acme",
+                                                  code: "ABCDEF",
+                                                  nutrition: TFoodDatumNutritionTests.nutrition,
+                                                  ingredients: [TFoodDatum.Ingredient(name: "Other")])
+    static let ingredientJSONDictionary: [String: Any] = [
+        "name": "Stuff",
+        "amount": TFoodDatumAmountTests.amountJSONDictionary,
+        "brand": "Acme",
+        "code": "ABCDEF",
+        "nutrition": TFoodDatumNutritionTests.nutritionJSONDictionary,
+        "ingredients": [["name": "Other"]]
+    ]
+    
+    func testInitializer() {
+        let ingredient = TFoodDatumIngredientTests.ingredient
+        XCTAssertEqual(ingredient.name, "Stuff")
+        XCTAssertEqual(ingredient.amount, TFoodDatumAmountTests.amount)
+        XCTAssertEqual(ingredient.brand, "Acme")
+        XCTAssertEqual(ingredient.code, "ABCDEF")
+        XCTAssertEqual(ingredient.nutrition, TFoodDatumNutritionTests.nutrition)
+        XCTAssertEqual(ingredient.ingredients, [TFoodDatum.Ingredient(name: "Other")])
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TFoodDatumIngredientTests.ingredient, TFoodDatumIngredientTests.ingredientJSONDictionary)
+    }
+}
+
+extension TFoodDatum {
+    func isEqual(to other: TFoodDatum) -> Bool {
+        return super.isEqual(to: other) &&
+            self.name == other.name &&
+            self.amount == other.amount &&
+            self.brand == other.brand &&
+            self.code == other.code &&
+            self.meal == other.meal &&
+            self.mealOther == other.mealOther &&
+            self.nutrition == other.nutrition &&
+            self.ingredients == other.ingredients
+    }
+}

--- a/TidepoolKitTests/Model/TAsssociationTests.swift
+++ b/TidepoolKitTests/Model/TAsssociationTests.swift
@@ -1,0 +1,76 @@
+//
+//  TAssociationTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 11/5/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TAssociationTests: XCTestCase {
+    static let association = TAssociation(type: .blob, id: "123456", reason: "Any reason is acceptable.")
+    static let assocationJSONDictionary: [String: Any] = [
+        "type": "blob",
+        "id": "123456",
+        "reason": "Any reason is acceptable."
+    ]
+    
+    func testInitializerWithTypeBlob() {
+        let association = TAssociation(type: .blob, id: "234567", reason: "Any reason is acceptable.")
+        XCTAssertEqual(association.type, .blob)
+        XCTAssertEqual(association.id, "234567")
+        XCTAssertEqual(association.reason, "Any reason is acceptable.")
+    }
+    
+    func testInitializerWithTypeDatum() {
+        let association = TAssociation(type: .datum, id: "345678", reason: "Any reason is acceptable.")
+        XCTAssertEqual(association.type, .datum)
+        XCTAssertEqual(association.id, "345678")
+        XCTAssertEqual(association.reason, "Any reason is acceptable.")
+    }
+    
+    func testInitializerWithTypeImage() {
+        let association = TAssociation(type: .image, id: "456789", reason: "Any reason is acceptable.")
+        XCTAssertEqual(association.type, .image)
+        XCTAssertEqual(association.id, "456789")
+        XCTAssertEqual(association.reason, "Any reason is acceptable.")
+    }
+    
+    func testInitializerWithTypeURL() {
+        let association = TAssociation(type: .url, url: "https://www.tidepool.org", reason: "Any reason is acceptable.")
+        XCTAssertEqual(association.type, .url)
+        XCTAssertEqual(association.url, "https://www.tidepool.org")
+        XCTAssertEqual(association.reason, "Any reason is acceptable.")
+    }
+    
+    func testCodableAsJSONWithTypeBlob() {
+        let association = TAssociation(type: .blob, id: "234567", reason: "Any reason is acceptable.")
+        XCTAssertCodableAsJSON(association, ["type": "blob", "id": "234567", "reason": "Any reason is acceptable."])
+    }
+    
+    func testCodableAsJSONWithTypeDatum() {
+        let association = TAssociation(type: .datum, id: "345678", reason: "Any reason is acceptable.")
+        XCTAssertCodableAsJSON(association, ["type": "datum", "id": "345678", "reason": "Any reason is acceptable."])
+    }
+    
+    func testCodableAsJSONWithTypeImage() {
+        let association = TAssociation(type: .image, id: "456789", reason: "Any reason is acceptable.")
+        XCTAssertCodableAsJSON(association, ["type": "image", "id": "456789", "reason": "Any reason is acceptable."])
+    }
+    
+    func testCodableAsJSONWithTypeURL() {
+        let association = TAssociation(type: .url, url: "https://www.tidepool.org", reason: "Any reason is acceptable.")
+        XCTAssertCodableAsJSON(association, ["type": "url", "url": "https://www.tidepool.org", "reason": "Any reason is acceptable."])
+    }
+}
+
+class TAssociationAssociationTypeTests: XCTestCase {
+    func testAssociationType() {
+        XCTAssertEqual(TAssociation.AssociationType.blob.rawValue, "blob")
+        XCTAssertEqual(TAssociation.AssociationType.datum.rawValue, "datum")
+        XCTAssertEqual(TAssociation.AssociationType.image.rawValue, "image")
+        XCTAssertEqual(TAssociation.AssociationType.url.rawValue, "url")
+    }
+}

--- a/TidepoolKitTests/Model/TBloodGlucoseTests.swift
+++ b/TidepoolKitTests/Model/TBloodGlucoseTests.swift
@@ -1,0 +1,67 @@
+//
+//  TBloodGlucoseTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 11/5/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TBloodGlucoseUnitsTests: XCTestCase {
+    func testUnits() {
+        XCTAssertEqual(TBloodGlucose.Units.milligramsPerDeciliter.rawValue, "mg/dL")
+        XCTAssertEqual(TBloodGlucose.Units.millimolesPerLiter.rawValue, "mmol/L")
+    }
+}
+
+class TBloodGlucoseTargetTests: XCTestCase {
+    static let target = TBloodGlucose.Target(target: 1.23)
+    static let targetJSONDictionary: [String: Any] = [
+        "target": 1.23
+    ]
+    
+    func testInitializerWithTarget() {
+        let target = TBloodGlucose.Target(target: 1.23)
+        XCTAssertEqual(target.target, 1.23)
+    }
+    
+    func testInitializerWithTargetAndRange() {
+        let target = TBloodGlucose.Target(target: 1.23, range: 2.34)
+        XCTAssertEqual(target.target, 1.23)
+        XCTAssertEqual(target.range, 2.34)
+    }
+    
+    func testInitializerWithTargetAndHigh() {
+        let target = TBloodGlucose.Target(target: 1.23, high: 2.34)
+        XCTAssertEqual(target.target, 1.23)
+        XCTAssertEqual(target.high, 2.34)
+    }
+    
+    func testInitializerWithLowAndHigh() {
+        let target = TBloodGlucose.Target(low: 1.23, high: 2.34)
+        XCTAssertEqual(target.low, 1.23)
+        XCTAssertEqual(target.high, 2.34)
+    }
+    
+    func testCodableAsJSONWithTarget() {
+        let target = TBloodGlucose.Target(target: 1.23)
+        XCTAssertCodableAsJSON(target, ["target": 1.23])
+    }
+    
+    func testCodableAsJSONWithTargetAndRange() {
+        let target = TBloodGlucose.Target(target: 1.23, range: 2.34)
+        XCTAssertCodableAsJSON(target, ["target": 1.23, "range": 2.34])
+    }
+    
+    func testCodableAsJSONWithTargetAndHigh() {
+        let target = TBloodGlucose.Target(target: 1.23, high: 2.34)
+        XCTAssertCodableAsJSON(target, ["target": 1.23, "high": 2.34])
+    }
+    
+    func testCodableAsJSONWithLowAndHigh() {
+        let target = TBloodGlucose.Target(low: 1.23, high: 2.34)
+        XCTAssertCodableAsJSON(target, ["low": 1.23, "high": 2.34])
+    }
+}

--- a/TidepoolKitTests/Model/TDataSetTests.swift
+++ b/TidepoolKitTests/Model/TDataSetTests.swift
@@ -1,0 +1,180 @@
+//
+//  TDataSetTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 3/3/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TDataSetTests: XCTestCase {
+    static let dataSet = TDataSet(byUser: "1234567890",
+                                  client: TDataSetClientTests.client,
+                                  computerTime: "2020-01-01T12:34:56",
+                                  conversionOffset: 123456,
+                                  createdTime: Date.test,
+                                  dataSetType: .normal,
+                                  deduplicator: TDataSetDeduplicatorTests.deduplicator,
+                                  deviceId: "ExampleDeviceId",
+                                  deviceManufacturers: ["Medtronic", "Dexcom"],
+                                  deviceModel: "ExampleDeviceModel",
+                                  deviceSerialNumber: "abcdefghijkl",
+                                  deviceTags: [.bgm, .cgm],
+                                  id: "2345678901",
+                                  modifiedTime: Date.test,
+                                  time: Date.test,
+                                  timeProcessing: .acrossTheBoardTimezone,
+                                  timezone: "Americas/Los_Angeles",
+                                  timezoneOffset: 234567,
+                                  uploadId: "3456789012",
+                                  version: "1.2.3")
+    static let dataSetJSONDictionary: [String: Any] = [
+        "byUser": "1234567890",
+        "client": TDataSetClientTests.clientJSONDictionary,
+        "computerTime": "2020-01-01T12:34:56",
+        "conversionOffset": 123456,
+        "createdTime": Date.testJSONString,
+        "dataSetType": "normal",
+        "deduplicator": TDataSetDeduplicatorTests.deduplicatorJSONDictionary,
+        "deviceId": "ExampleDeviceId",
+        "deviceManufacturers": ["Medtronic", "Dexcom"],
+        "deviceModel": "ExampleDeviceModel",
+        "deviceSerialNumber": "abcdefghijkl",
+        "deviceTags": ["bgm", "cgm"],
+        "id": "2345678901",
+        "modifiedTime": Date.testJSONString,
+        "time": Date.testJSONString,
+        "timeProcessing": "across-the-board-timezone",
+        "timezone": "Americas/Los_Angeles",
+        "timezoneOffset": 234567,
+        "type": "upload",
+        "uploadId": "3456789012",
+        "version": "1.2.3"
+    ]
+    
+    func testInitializer() {
+        let dataSet = TDataSetTests.dataSet
+        XCTAssertEqual(dataSet.byUser, "1234567890")
+        XCTAssertEqual(dataSet.client, TDataSetClientTests.client)
+        XCTAssertEqual(dataSet.computerTime, "2020-01-01T12:34:56")
+        XCTAssertEqual(dataSet.conversionOffset, 123456)
+        XCTAssertEqual(dataSet.createdTime, Date.test)
+        XCTAssertEqual(dataSet.dataSetType, .normal)
+        XCTAssertEqual(dataSet.deduplicator, TDataSetDeduplicatorTests.deduplicator)
+        XCTAssertEqual(dataSet.deviceId, "ExampleDeviceId")
+        XCTAssertEqual(dataSet.deviceManufacturers, ["Medtronic", "Dexcom"])
+        XCTAssertEqual(dataSet.deviceModel, "ExampleDeviceModel")
+        XCTAssertEqual(dataSet.deviceSerialNumber, "abcdefghijkl")
+        XCTAssertEqual(dataSet.deviceTags, [.bgm, .cgm])
+        XCTAssertEqual(dataSet.id, "2345678901")
+        XCTAssertEqual(dataSet.modifiedTime, Date.test)
+        XCTAssertEqual(dataSet.time, Date.test)
+        XCTAssertEqual(dataSet.timeProcessing, .acrossTheBoardTimezone)
+        XCTAssertEqual(dataSet.timezone, "Americas/Los_Angeles")
+        XCTAssertEqual(dataSet.timezoneOffset, 234567)
+        XCTAssertEqual(dataSet.uploadId, "3456789012")
+        XCTAssertEqual(dataSet.version, "1.2.3")
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TDataSetTests.dataSet, TDataSetTests.dataSetJSONDictionary)
+    }
+}
+
+class TDataSetDataSetTypeTests: XCTestCase {
+    func testDataSetType() {
+        XCTAssertEqual(TDataSet.DataSetType.continuous.rawValue, "continuous")
+        XCTAssertEqual(TDataSet.DataSetType.normal.rawValue, "normal")
+    }
+}
+
+class TDataSetDeviceTagTests: XCTestCase {
+    func testDeviceTag() {
+        XCTAssertEqual(TDataSet.DeviceTag.bgm.rawValue, "bgm")
+        XCTAssertEqual(TDataSet.DeviceTag.cgm.rawValue, "cgm")
+        XCTAssertEqual(TDataSet.DeviceTag.insulinPump.rawValue, "insulin-pump")
+    }
+}
+
+class TDataSetTimeProcessingTests: XCTestCase {
+    func testTimeProcessing() {
+        XCTAssertEqual(TDataSet.TimeProcessing.acrossTheBoardTimezone.rawValue, "across-the-board-timezone")
+        XCTAssertEqual(TDataSet.TimeProcessing.none.rawValue, "none")
+        XCTAssertEqual(TDataSet.TimeProcessing.utcBootstrapping.rawValue, "utc-bootstrapping")
+    }
+}
+
+class TDataSetClientTests: XCTestCase {
+    static let client = TDataSet.Client(name: "org.tidepool.Example", version: "1.2.3", payload: TDictionary(["a": "b", "c": 0]))
+    static let clientJSONDictionary: [String: Any] = [
+        "name": "org.tidepool.Example",
+        "version": "1.2.3",
+        "private": ["a": "b", "c": 0]
+    ]
+    
+    func testInitializer() {
+        let client = TDataSetClientTests.client
+        XCTAssertEqual(client.name, "org.tidepool.Example")
+        XCTAssertEqual(client.version, "1.2.3")
+        XCTAssertEqual(client.payload, TDictionary(["a": "b", "c": 0]))
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TDataSetClientTests.client, TDataSetClientTests.clientJSONDictionary)
+    }
+}
+
+class TDataSetDeduplicatorTests: XCTestCase {
+    static let deduplicator = TDataSet.Deduplicator(name: .dataSetDeleteOrigin, version: "1.2.3")
+    static let deduplicatorJSONDictionary: [String: Any] = [
+        "name": "org.tidepool.deduplicator.dataset.delete.origin",
+        "version": "1.2.3"
+    ]
+    
+    func testInitializer() {
+        let deduplicator = TDataSetDeduplicatorTests.deduplicator
+        XCTAssertEqual(deduplicator.name, .dataSetDeleteOrigin)
+        XCTAssertEqual(deduplicator.version, "1.2.3")
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TDataSetDeduplicatorTests.deduplicator, TDataSetDeduplicatorTests.deduplicatorJSONDictionary)
+    }
+}
+
+class TDataSetDeduplicatorNameTests: XCTestCase {
+    func testName() {
+        XCTAssertEqual(TDataSet.Deduplicator.Name.dataSetDeleteOrigin.rawValue, "org.tidepool.deduplicator.dataset.delete.origin")
+        XCTAssertEqual(TDataSet.Deduplicator.Name.deviceDeactivateHash.rawValue, "org.tidepool.deduplicator.device.deactivate.hash")
+        XCTAssertEqual(TDataSet.Deduplicator.Name.deviceTruncateDataSet.rawValue, "org.tidepool.deduplicator.device.truncate.dataset")
+        XCTAssertEqual(TDataSet.Deduplicator.Name.none.rawValue, "org.tidepool.deduplicator.none")
+    }
+    
+    func testLegacyNamesDecoding() {
+        func decodeLegacyNames() throws {
+            let legacyNames = ["org.tidepool.continuous.origin", "org.tidepool.hash-deactivate-old", "org.tidepool.truncate", "org.tidepool.continuous"]
+            let decodedNames = try JSONDecoder.tidepool.decode([TDataSet.Deduplicator.Name].self, from: try JSONEncoder.tidepool.encode(legacyNames))
+            XCTAssertEqual(decodedNames, [.dataSetDeleteOrigin, .deviceDeactivateHash, .deviceTruncateDataSet, .none])
+        }
+        XCTAssertNoThrow(decodeLegacyNames)
+    }
+}
+
+class TDataSetFilterTests: XCTestCase {
+    static let filter = TDataSet.Filter(clientName: "org.tidepool.Example", deleted: true, deviceId: "ExampleDeviceId")
+    
+    func testInitializer() {
+        let filter = TDataSetFilterTests.filter
+        XCTAssertEqual(filter.clientName, "org.tidepool.Example")
+        XCTAssertEqual(filter.deleted, true)
+        XCTAssertEqual(filter.deviceId, "ExampleDeviceId")
+    }
+    
+    func testQueryItems() {
+        XCTAssertEqual(TDataSetFilterTests.filter.queryItems, [URLQueryItem(name: "client.name", value: "org.tidepool.Example"),
+                                                               URLQueryItem(name: "deleted", value: "true"),
+                                                               URLQueryItem(name: "deviceId", value: "ExampleDeviceId")])
+    }
+}

--- a/TidepoolKitTests/Model/TLocationTests.swift
+++ b/TidepoolKitTests/Model/TLocationTests.swift
@@ -1,0 +1,161 @@
+//
+//  TLocationTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 11/5/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TLocationTests: XCTestCase {
+    static let location = TLocation(name: "Home", gps: TLocationGPSTests.gps)
+    static let locationJSONDictionary: [String: Any] = [
+        "name": "Home",
+        "gps": TLocationGPSTests.gpsJSONDictionary
+    ]
+    
+    func testInitializer() {
+        let location = TLocationTests.location
+        XCTAssertEqual(location.name, "Home")
+        XCTAssertEqual(location.gps, TLocationGPSTests.gps)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TLocationTests.location, TLocationTests.locationJSONDictionary)
+    }
+}
+
+class TLocationGPSTests: XCTestCase {
+    static let gps = TLocation.GPS(
+        latitude: TLocationGPSLatitudeTests.latitude,
+        longitude: TLocationGPSLongitudeTests.longitude,
+        elevation: TLocationGPSElevationTests.elevation,
+        floor: 7,
+        horizontalAccuracy: TLocationGPSAccuracyTests.accuracy,
+        verticalAccuracy: TLocationGPSAccuracyTests.accuracy,
+        origin: TOriginTests.origin)
+    static let gpsJSONDictionary: [String: Any] = [
+        "latitude": TLocationGPSLatitudeTests.latitudeJSONDictionary,
+        "longitude": TLocationGPSLongitudeTests.longitudeJSONDictionary,
+        "elevation": TLocationGPSElevationTests.elevationJSONDictionary,
+        "floor": 7,
+        "horizontalAccuracy": TLocationGPSAccuracyTests.accuracyJSONDictionary,
+        "verticalAccuracy": TLocationGPSAccuracyTests.accuracyJSONDictionary,
+        "origin": TOriginTests.originJSONDictionary
+    ]
+    
+    func testInitializer() {
+        let gps = TLocationGPSTests.gps
+        XCTAssertEqual(gps.latitude, TLocationGPSLatitudeTests.latitude)
+        XCTAssertEqual(gps.longitude, TLocationGPSLongitudeTests.longitude)
+        XCTAssertEqual(gps.elevation, TLocationGPSElevationTests.elevation)
+        XCTAssertEqual(gps.floor, 7)
+        XCTAssertEqual(gps.horizontalAccuracy, TLocationGPSAccuracyTests.accuracy)
+        XCTAssertEqual(gps.verticalAccuracy, TLocationGPSAccuracyTests.accuracy)
+        XCTAssertEqual(gps.origin, TOriginTests.origin)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TLocationGPSTests.gps, TLocationGPSTests.gpsJSONDictionary)
+    }
+}
+
+class TLocationGPSLatitudeTests: XCTestCase {
+    static let latitude = TLocation.GPS.Latitude(1.23)
+    static let latitudeJSONDictionary: [String: Any] = [
+        "value": 1.23,
+        "units": "degrees"
+    ]
+    
+    func testInitializer() {
+        let latitude = TLocationGPSLatitudeTests.latitude
+        XCTAssertEqual(latitude.value, 1.23)
+        XCTAssertEqual(latitude.units, .degrees)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TLocationGPSLatitudeTests.latitude, TLocationGPSLatitudeTests.latitudeJSONDictionary)
+    }
+}
+
+class TLocationGPSLatitudeUnitsTests: XCTestCase {
+    func testUnits() {
+        XCTAssertEqual(TLocation.GPS.Latitude.Units.degrees.rawValue, "degrees")
+    }
+}
+
+class TLocationGPSLongitudeTests: XCTestCase {
+    static let longitude = TLocation.GPS.Longitude(1.23)
+    static let longitudeJSONDictionary: [String: Any] = [
+        "value": 1.23,
+        "units": "degrees"
+    ]
+    
+    func testInitializer() {
+        let longitude = TLocationGPSLongitudeTests.longitude
+        XCTAssertEqual(longitude.value, 1.23)
+        XCTAssertEqual(longitude.units, .degrees)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TLocationGPSLongitudeTests.longitude, TLocationGPSLongitudeTests.longitudeJSONDictionary)
+    }
+}
+
+class TLocationGPSLongitudeUnitsTests: XCTestCase {
+    func testUnits() {
+        XCTAssertEqual(TLocation.GPS.Longitude.Units.degrees.rawValue, "degrees")
+    }
+}
+
+class TLocationGPSElevationTests: XCTestCase {
+    static let elevation = TLocation.GPS.Elevation(1.23, .feet)
+    static let elevationJSONDictionary: [String: Any] = [
+        "value": 1.23,
+        "units": "feet"
+    ]
+    
+    func testInitializer() {
+        let elevation = TLocationGPSElevationTests.elevation
+        XCTAssertEqual(elevation.value, 1.23)
+        XCTAssertEqual(elevation.units, .feet)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TLocationGPSElevationTests.elevation, TLocationGPSElevationTests.elevationJSONDictionary)
+    }
+}
+
+class TLocationGPSElevationUnitsTests: XCTestCase {
+    func testUnits() {
+        XCTAssertEqual(TLocation.GPS.Elevation.Units.feet.rawValue, "feet")
+        XCTAssertEqual(TLocation.GPS.Elevation.Units.meters.rawValue, "meters")
+    }
+}
+
+class TLocationGPSAccuracyTests: XCTestCase {
+    static let accuracy = TLocation.GPS.Accuracy(1.23, .feet)
+    static let accuracyJSONDictionary: [String: Any] = [
+        "value": 1.23,
+        "units": "feet"
+    ]
+    
+    func testInitializer() {
+        let accuracy = TLocationGPSAccuracyTests.accuracy
+        XCTAssertEqual(accuracy.value, 1.23)
+        XCTAssertEqual(accuracy.units, .feet)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TLocationGPSAccuracyTests.accuracy, TLocationGPSAccuracyTests.accuracyJSONDictionary)
+    }
+}
+
+class TLocationGPSAccuracyUnitsTests: XCTestCase {
+    func testUnits() {
+        XCTAssertEqual(TLocation.GPS.Accuracy.Units.feet.rawValue, "feet")
+        XCTAssertEqual(TLocation.GPS.Accuracy.Units.meters.rawValue, "meters")
+    }
+}

--- a/TidepoolKitTests/Model/TOriginTests.swift
+++ b/TidepoolKitTests/Model/TOriginTests.swift
@@ -1,0 +1,49 @@
+//
+//  TOriginTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 11/5/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TOriginTests: XCTestCase {
+    static let origin = TOrigin(id: "abcdef",
+                                name: "Test Origin",
+                                version: "1.2.3",
+                                type: .device,
+                                time: Date.test,
+                                payload: TDictionary(["a": "b", "c": 0]))
+    static let originJSONDictionary: [String: Any] = [
+        "id": "abcdef",
+        "name": "Test Origin",
+        "version": "1.2.3",
+        "type": "device",
+        "time": Date.testJSONString,
+        "payload": ["a": "b", "c": 0]
+    ]
+    
+    func testInitializer() {
+        let origin = TOriginTests.origin
+        XCTAssertEqual(origin.id, "abcdef")
+        XCTAssertEqual(origin.name, "Test Origin")
+        XCTAssertEqual(origin.version, "1.2.3")
+        XCTAssertEqual(origin.time, Date.test)
+        XCTAssertEqual(origin.type, .device)
+        XCTAssertEqual(origin.payload, TDictionary(["a": "b", "c": 0]))
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TOriginTests.origin, TOriginTests.originJSONDictionary)
+    }
+}
+
+class TOriginOriginTypeTests: XCTestCase {
+    func testOriginType() {
+        XCTAssertEqual(TOrigin.OriginType.device.rawValue, "device")
+        XCTAssertEqual(TOrigin.OriginType.manual.rawValue, "manual")
+        XCTAssertEqual(TOrigin.OriginType.service.rawValue, "service")
+    }
+}

--- a/TidepoolKitTests/Model/TProfileTests.swift
+++ b/TidepoolKitTests/Model/TProfileTests.swift
@@ -1,0 +1,68 @@
+//
+//  TProfileTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 3/3/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TProfileTests: XCTestCase {
+    static let profile = TProfile(fullName: "John Doe", patient: TProfilePatientTests.patient)
+    static let profileJSONDictionary: [String: Any] = [
+        "fullName": "John Doe",
+        "patient": TProfilePatientTests.patientJSONDictionary
+    ]
+    
+    func testInitializer() {
+        let profile = TProfileTests.profile
+        XCTAssertEqual(profile.fullName, "John Doe")
+        XCTAssertEqual(profile.patient, TProfilePatientTests.patient)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TProfileTests.profile, TProfileTests.profileJSONDictionary)
+    }
+}
+
+class TProfilePatientTests: XCTestCase {
+    static let patient = TProfile.Patient(isOtherPerson: true,
+                                          fullName: "Jane Doe",
+                                          birthday: "12/31/1999",
+                                          diagnosisDate: "1/1/2009",
+                                          diagnosisType: "type1",
+                                          biologicalSex: "female",
+                                          targetTimezone: "Americas/Los_Angeles",
+                                          targetDevices: ["Medtronic", "Dexcom"],
+                                          about: "This is an about box.")
+    static let patientJSONDictionary: [String: Any] = [
+        "isOtherPerson": true,
+        "fullName": "Jane Doe",
+        "birthday": "12/31/1999",
+        "diagnosisDate": "1/1/2009",
+        "diagnosisType": "type1",
+        "biologicalSex": "female",
+        "targetTimezone": "Americas/Los_Angeles",
+        "targetDevices": ["Medtronic", "Dexcom"],
+        "about": "This is an about box."
+    ]
+    
+    func testInitializer() {
+        let patient = TProfilePatientTests.patient
+        XCTAssertEqual(patient.isOtherPerson, true)
+        XCTAssertEqual(patient.fullName, "Jane Doe")
+        XCTAssertEqual(patient.birthday, "12/31/1999")
+        XCTAssertEqual(patient.diagnosisDate, "1/1/2009")
+        XCTAssertEqual(patient.diagnosisType, "type1")
+        XCTAssertEqual(patient.biologicalSex, "female")
+        XCTAssertEqual(patient.targetTimezone, "Americas/Los_Angeles")
+        XCTAssertEqual(patient.targetDevices, ["Medtronic", "Dexcom"])
+        XCTAssertEqual(patient.about, "This is an about box.")
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TProfilePatientTests.patient, TProfilePatientTests.patientJSONDictionary)
+    }
+}

--- a/TidepoolKitTests/TAPITests.swift
+++ b/TidepoolKitTests/TAPITests.swift
@@ -1,0 +1,547 @@
+//
+//  TAPITests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 3/3/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+@testable import TidepoolKit
+
+class TAPITests: XCTestCase {
+    var api: TAPI!
+    var environment: TEnvironment!
+    let authenticationToken = randomString
+    let userId = randomString
+
+    override func setUp() {
+        super.setUp()
+
+        self.api = TAPI(automaticallyFetchEnvironments: false)
+        self.api.urlSessionConfiguration.protocolClasses = [URLProtocolMock.self]
+        self.environment = TEnvironment(host: "test.org", port: 443)
+    }
+
+    static var randomString: String { UUID().uuidString }
+
+    struct TestError: Error {}
+}
+
+class TAPIEnvironmentTests: TAPITests {
+    func testDefaultEnvironment() {
+        XCTAssertEqual(api.environments, [TEnvironment(host: "app.tidepool.org", port: 443)])
+    }
+}
+
+class TAPIURLSessionConfigurationTests: TAPITests {
+    func testDefaultURLSessionConfiguration() {
+        let urlSessionConfiguration = api.urlSessionConfiguration
+        XCTAssertEqual(urlSessionConfiguration.waitsForConnectivity, true)
+        XCTAssertNotNil(urlSessionConfiguration.httpAdditionalHeaders)
+        XCTAssertNotNil(urlSessionConfiguration.httpAdditionalHeaders?["User-Agent"])
+        XCTAssertNotNil(urlSessionConfiguration.protocolClasses)
+    }
+}
+
+class TAPILoginTests: TAPITests {
+    let email = randomString
+    let password = randomString
+
+    override func setUp() {
+        super.setUp()
+
+        URLProtocolMock.validator = URLProtocolMock.Validator(url: "https://test.org/auth/login",
+                                                              method: "POST",
+                                                              headers: ["Authorization": "Basic \(Data("\(email):\(password)".utf8).base64EncodedString())"])
+        URLProtocolMock.error = nil
+        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 201,
+                                                          headers: ["X-Tidepool-Session-Token": authenticationToken],
+                                                          body: LoginResponse(userId: userId, email: email, emailVerified: true, termsAccepted: "2010-01-01T12:34:56Z"))
+    }
+
+    func testNetworkError() {
+        URLProtocolMock.error = TestError()
+        guard case .failure(let error) = performRequest(), case .network(let networkError) = error else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(networkError as? TestError)
+    }
+
+    func testRequestNotAuthenticated() {
+        URLProtocolMock.success?.statusCode = 401
+        guard case .failure(let error) = performRequest(), case .requestNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testRequestEmailNotVerified() {
+        URLProtocolMock.success?.statusCode = 403
+        guard case .failure(let error) = performRequest(), case .requestEmailNotVerified = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testResponseNotAuthenticated() {
+        URLProtocolMock.success?.headers = nil
+        guard case .failure(let error) = performRequest(), case .responseNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testResponseMalformedJSON() {
+        URLProtocolMock.success?.body = nil
+        guard case .failure(let error) = performRequest(), case .responseMalformedJSON = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testTermsOfUseNotAccepted() {
+        URLProtocolMock.success?.set(body: LoginResponse(userId: userId, email: email, emailVerified: true))
+        guard case .failure(let error) = performRequest(), case .requestTermsOfServiceNotAccepted = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testSuccess() {
+        guard case .success(let session) = performRequest() else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(session.environment, self.environment)
+        XCTAssertEqual(session.authenticationToken, authenticationToken)
+        XCTAssertEqual(session.userId, userId)
+        XCTAssertNotNil(session.trace)
+    }
+
+    private func performRequest() -> Result<TSession, TError>? {
+        let expectation = XCTestExpectationWithResult<TSession, TError>()
+        api.login(environment: environment, email: email, password: password) { expectation.fulfill($0) }
+        XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
+        return expectation.result
+    }
+}
+
+class TAPISessionTests: TAPITests {
+    var session: TSession!
+    var headers: [String: String]!
+
+    override func setUp() {
+        super.setUp()
+
+        session = TSession(environment: environment, authenticationToken: authenticationToken, userId: userId)
+        headers = ["X-Tidepool-Session-Token": authenticationToken, "X-Tidepool-Trace-Session": session.trace!]
+    }
+}
+
+class TAPIRefreshTests: TAPISessionTests {
+    let refreshedAuthenticationToken = randomString
+
+    override func setUp() {
+        super.setUp()
+
+        URLProtocolMock.validator = URLProtocolMock.Validator(url: "https://test.org/auth/login", method: "GET", headers: headers)
+        URLProtocolMock.error = nil
+        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200, headers: ["X-Tidepool-Session-Token": refreshedAuthenticationToken])
+    }
+
+    func testNetworkError() {
+        URLProtocolMock.error = TestError()
+        guard case .failure(let error) = performRequest(), case .network(let networkError) = error else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(networkError as? TestError)
+    }
+
+    func testRequestNotAuthenticated() {
+        URLProtocolMock.success?.statusCode = 401
+        guard case .failure(let error) = performRequest(), case .requestNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testResponseNotAuthenticated() {
+        URLProtocolMock.success?.headers = nil
+        guard case .failure(let error) = performRequest(), case .responseNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testSuccess() {
+        guard case .success(let refreshedSession) = performRequest() else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(refreshedSession.environment, session.environment)
+        XCTAssertNotEqual(refreshedSession.authenticationToken, session.authenticationToken)
+        XCTAssertEqual(refreshedSession.userId, session.userId)
+        XCTAssertEqual(refreshedSession.trace, session.trace)
+    }
+
+    private func performRequest() -> Result<TSession, TError>? {
+        let expectation = XCTestExpectationWithResult<TSession, TError>()
+        api.refresh(session: session) { expectation.fulfill($0) }
+        XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
+        return expectation.result
+    }
+}
+
+class TAPILogoutTests: TAPISessionTests {
+    override func setUp() {
+        super.setUp()
+
+        URLProtocolMock.validator = URLProtocolMock.Validator(url: "https://test.org/auth/logout", method: "POST", headers: headers)
+        URLProtocolMock.error = nil
+        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200)
+    }
+
+    func testNetworkError() {
+        URLProtocolMock.error = TestError()
+        guard let error = performRequest(), case .network(let networkError) = error else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(networkError as? TestError)
+    }
+
+    func testRequestNotAuthenticated() {
+        URLProtocolMock.success?.statusCode = 401
+        guard let error = performRequest(), case .requestNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testSuccess() {
+        guard performRequest() == nil else {
+            XCTFail()
+            return
+        }
+    }
+
+    private func performRequest() -> TError? {
+        let expectation = XCTestExpectationWithError()
+        api.logout(session: session) { expectation.fulfill($0) }
+        XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
+        return expectation.error
+    }
+}
+
+class TAPIGetProfileTests: TAPISessionTests {
+    override func setUp() {
+        super.setUp()
+
+        URLProtocolMock.validator = URLProtocolMock.Validator(url: "https://test.org/metadata/\(userId)/profile", method: "GET", headers: headers)
+        URLProtocolMock.error = nil
+        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200, headers: headers, body: TProfileTests.profile)
+    }
+
+    func testNetworkError() {
+        URLProtocolMock.error = TestError()
+        guard case .failure(let error) = performRequest(), case .network(let networkError) = error else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(networkError as? TestError)
+    }
+
+    func testRequestNotAuthenticated() {
+        URLProtocolMock.success?.statusCode = 401
+        guard case .failure(let error) = performRequest(), case .requestNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testRequestNotAuthorized() {
+        URLProtocolMock.success?.statusCode = 403
+        guard case .failure(let error) = performRequest(), case .requestNotAuthorized = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testResponseMalformedJSON() {
+        URLProtocolMock.success?.body = nil
+        guard case .failure(let error) = performRequest(), case .responseMalformedJSON = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testSuccess() {
+        guard case .success(let profile) = performRequest() else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(profile, TProfileTests.profile)
+    }
+
+    private func performRequest() -> Result<TProfile, TError>? {
+        let expectation = XCTestExpectationWithResult<TProfile, TError>()
+        api.getProfile(session: session) { expectation.fulfill($0) }
+        XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
+        return expectation.result
+    }
+}
+
+class TAPIListDataSetsTests: TAPISessionTests {
+    override func setUp() {
+        super.setUp()
+
+        let url = "https://test.org/v1/users/\(userId)/data_sets?client.name=org.tidepool.Example&deleted=true&deviceId=ExampleDeviceId"
+        URLProtocolMock.validator = URLProtocolMock.Validator(url: url, method: "GET", headers: headers)
+        URLProtocolMock.error = nil
+        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200, headers: headers, body: [TDataSetTests.dataSet])
+    }
+
+    func testNetworkError() {
+        URLProtocolMock.error = TestError()
+        guard case .failure(let error) = performRequest(), case .network(let networkError) = error else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(networkError as? TestError)
+    }
+
+    func testRequestNotAuthenticated() {
+        URLProtocolMock.success?.statusCode = 401
+        guard case .failure(let error) = performRequest(), case .requestNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testRequestNotAuthorized() {
+        URLProtocolMock.success?.statusCode = 403
+        guard case .failure(let error) = performRequest(), case .requestNotAuthorized = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testResponseMalformedJSON() {
+        URLProtocolMock.success?.body = nil
+        guard case .failure(let error) = performRequest(), case .responseMalformedJSON = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testSuccess() {
+        guard case .success(let dataSets) = performRequest() else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(dataSets, [TDataSetTests.dataSet])
+    }
+
+    private func performRequest() -> Result<[TDataSet], TError>? {
+        let expectation = XCTestExpectationWithResult<[TDataSet], TError>()
+        api.listDataSets(filter: TDataSetFilterTests.filter, session: session) { expectation.fulfill($0) }
+        XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
+        return expectation.result
+    }
+}
+
+class TAPICreateDataSetTests: TAPISessionTests {
+    var dataSet: TDataSet!
+
+    override func setUp() {
+        super.setUp()
+
+        dataSet = TDataSet(dataSetType: .continuous, client: TDataSetClientTests.client, deduplicator: TDataSet.Deduplicator(name: .dataSetDeleteOrigin))
+        URLProtocolMock.validator = URLProtocolMock.Validator(url: "https://test.org/v1/users/\(userId)/data_sets", method: "POST", headers: headers, body: dataSet)
+        URLProtocolMock.error = nil
+        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200, headers: headers, body: LegacyResponse.Success(data: TDataSetTests.dataSet))
+    }
+
+    func testNetworkError() {
+        URLProtocolMock.error = TestError()
+        guard case .failure(let error) = performRequest(), case .network(let networkError) = error else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(networkError as? TestError)
+    }
+
+    func testRequestNotAuthenticated() {
+        URLProtocolMock.success?.statusCode = 401
+        guard case .failure(let error) = performRequest(), case .requestNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testRequestNotAuthorized() {
+        URLProtocolMock.success?.statusCode = 403
+        guard case .failure(let error) = performRequest(), case .requestNotAuthorized = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testResponseMalformedJSON() {
+        URLProtocolMock.success?.body = nil
+        guard case .failure(let error) = performRequest(), case .responseMalformedJSON = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testSuccess() {
+        guard case .success(let createdDataSet) = performRequest() else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(createdDataSet, TDataSetTests.dataSet)
+    }
+
+    private func performRequest() -> Result<TDataSet, TError>? {
+        let expectation = XCTestExpectationWithResult<TDataSet, TError>()
+        api.createDataSet(dataSet, session: session) { expectation.fulfill($0) }
+        XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
+        return expectation.result
+    }
+}
+
+class TAPIListDataTests: TAPISessionTests {
+    override func setUp() {
+        super.setUp()
+
+        let url = "https://test.org/data/\(userId)?startDate=\(Date.testJSONString)"
+        URLProtocolMock.validator = URLProtocolMock.Validator(url: url, method: "GET", headers: headers)
+        URLProtocolMock.error = nil
+        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200, headers: headers, body: [TCBGDatumTests.cbg, TFoodDatumTests.food])
+    }
+
+    func testNetworkError() {
+        URLProtocolMock.error = TestError()
+        guard case .failure(let error) = performRequest(), case .network(let networkError) = error else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(networkError as? TestError)
+    }
+
+    func testRequestNotAuthenticated() {
+        URLProtocolMock.success?.statusCode = 401
+        guard case .failure(let error) = performRequest(), case .requestNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testRequestNotAuthorized() {
+        URLProtocolMock.success?.statusCode = 403
+        guard case .failure(let error) = performRequest(), case .requestNotAuthorized = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testResponseMalformedJSON() {
+        URLProtocolMock.success?.body = nil
+        guard case .failure(let error) = performRequest(), case .responseMalformedJSON = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testSuccess() {
+        guard case .success((let data, let malformed)) = performRequest() else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(data, [TCBGDatumTests.cbg, TFoodDatumTests.food])
+        XCTAssertEqual(malformed.count, 0)
+    }
+
+    private func performRequest() -> Result<([TDatum], [Int: [String:Any]]), TError>? {
+        let expectation = XCTestExpectationWithResult<([TDatum], [Int: [String:Any]]), TError>()
+        api.listData(filter: TDatum.Filter(startDate: Date.test), session: session) { expectation.fulfill($0) }
+        XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
+        return expectation.result
+    }
+}
+
+class TAPICreateDataTests: TAPISessionTests {
+    let dataSetId = randomString
+    let data = [TCBGDatumTests.cbg, TFoodDatumTests.food]
+
+    override func setUp() {
+        super.setUp()
+
+        URLProtocolMock.validator = URLProtocolMock.Validator(url: "https://test.org/v1/data_sets/\(dataSetId)/data", method: "POST", headers: headers, body: data)
+        URLProtocolMock.error = nil
+        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200, headers: headers, body: LegacyResponse.Success<DataResponse>(data: DataResponse()))
+    }
+
+    func testNetworkError() {
+        URLProtocolMock.error = TestError()
+        guard let error = performRequest(), case .network(let networkError) = error else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(networkError as? TestError)
+    }
+
+    func testRequestNotAuthenticated() {
+        URLProtocolMock.success?.statusCode = 401
+        guard let error = performRequest(), case .requestNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testRequestNotAuthorized() {
+        URLProtocolMock.success?.statusCode = 403
+        guard let error = performRequest(), case .requestNotAuthorized = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testRequestMalformedJSON() {
+        let errors = [TError.Detail(code: "code-123", title: "title-123", detail: "detail-123"),
+                      TError.Detail(code: "code-456", title: "title-456", detail: "detail-456"),
+                      TError.Detail(code: "code-789", title: "title-789", detail: "detail-789")]
+        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 400, headers: headers, body: LegacyResponse.Failure(errors: errors))
+        guard let error = performRequest(), case .requestMalformedJSON(_, _, let malformedJSONErrors) = error else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(malformedJSONErrors, errors)
+    }
+
+    func testResponseMalformedJSON() {
+        URLProtocolMock.success?.body = nil
+        guard let error = performRequest(), case .responseMalformedJSON = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testSuccess() {
+        guard performRequest() == nil else {
+            XCTFail()
+            return
+        }
+    }
+
+    private func performRequest() -> TError? {
+        let expectation = XCTestExpectationWithError()
+        api.createData(data, dataSetId: dataSetId, session: session) { expectation.fulfill($0) }
+        XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
+        return expectation.error
+    }
+}

--- a/TidepoolKitTests/TEnvironmentTests.swift
+++ b/TidepoolKitTests/TEnvironmentTests.swift
@@ -1,0 +1,69 @@
+//
+//  TEnvironmentTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 3/3/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TEnvironmentTests: XCTestCase {
+    static let environment = TEnvironment(host: "test.tidepool.org", port: 443)
+    static let environmentJSONDictionary: [String: Any] = [
+        "host": "test.tidepool.org",
+        "port": 443
+    ]
+
+    func testInitializer() {
+        let environment = TEnvironmentTests.environment
+        XCTAssertEqual(environment.host, "test.tidepool.org")
+        XCTAssertEqual(environment.port, 443)
+    }
+
+    func testURLWithPort80() {
+        let url = TEnvironment(host: "test.tidepool.org", port: 80).url()
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url!.absoluteString, "http://test.tidepool.org/")
+    }
+
+    func testURLWithPort443() {
+        let url = TEnvironment(host: "test.tidepool.org", port: 443).url()
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url!.absoluteString, "https://test.tidepool.org/")
+    }
+
+    func testURLWithPortOther() {
+        let url = TEnvironment(host: "test.tidepool.org", port: 3000).url()
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url!.absoluteString, "http://test.tidepool.org:3000/")
+    }
+
+    func testURLWithPathWithoutPrefix() {
+        let url = TEnvironmentTests.environment.url(path: "alpha/beta")
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url!.absoluteString, "https://test.tidepool.org/alpha/beta")
+    }
+
+    func testURLWithPathWithPrefix() {
+        let url = TEnvironmentTests.environment.url(path: "/alpha/beta")
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url!.absoluteString, "https://test.tidepool.org/alpha/beta")
+    }
+
+    func testURLWithQueryItems() {
+        let queryItems = [URLQueryItem(name: "foo", value: "one"), URLQueryItem(name: "bar", value: "two")]
+        let url = TEnvironmentTests.environment.url(path: "/alpha/beta", queryItems: queryItems)
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url!.absoluteString, "https://test.tidepool.org/alpha/beta?foo=one&bar=two")
+    }
+
+    func testDescription() {
+        XCTAssertEqual(TEnvironmentTests.environment.description, "test.tidepool.org:443")
+    }
+
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TEnvironmentTests.environment, TEnvironmentTests.environmentJSONDictionary)
+    }
+}

--- a/TidepoolKitTests/TSessionTests.swift
+++ b/TidepoolKitTests/TSessionTests.swift
@@ -1,0 +1,35 @@
+//
+//  TSessionTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 3/3/20.
+//  Copyright © 2020 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TSessionTests: XCTestCase {
+    static let session = TSession(environment: TEnvironmentTests.environment,
+                                  authenticationToken: "test-authentication-token",
+                                  userId: "1234567890",
+                                  trace: "test-trace")
+    static let sessionJSONDictionary: [String: Any] = [
+        "environment": TEnvironmentTests.environmentJSONDictionary,
+        "authenticationToken": "test-authentication-token",
+        "userId": "1234567890",
+        "trace": "test-trace"
+    ]
+
+    func testInitializer() {
+        let session = TSessionTests.session
+        XCTAssertEqual(session.environment, TEnvironmentTests.environment)
+        XCTAssertEqual(session.authenticationToken, "test-authentication-token")
+        XCTAssertEqual(session.userId, "1234567890")
+        XCTAssertEqual(session.trace, "test-trace")
+    }
+
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TSessionTests.session, TSessionTests.sessionJSONDictionary)
+    }
+}

--- a/TidepoolKitUI/Internal/LoginSignupViewController.swift
+++ b/TidepoolKitUI/Internal/LoginSignupViewController.swift
@@ -77,7 +77,10 @@ class LoginSignupViewController: UIViewController, TLoginSignup {
                 DispatchQueue.main.async {
                     self.activityIndicatorView.stopAnimating()
                     if let error = self.delegate?.loginSignup(self, didCreateSession: session) {
-                        self.feedbackLabel.text = error.localizedDescription
+                        TSharedLogging.error((error as CustomDebugStringConvertible).debugDescription)
+                        DispatchQueue.main.async {
+                            self.feedbackLabel.text = error.localizedDescription
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-4
- https://tidepool.atlassian.net/browse/LOOP-6
- Get profile, list/create data sets, list/create data APIs
- Use Tidepool API compliant JSON encoding and decoding
- Defacto encoding and decoding for generic dictionary from JSON
- Implement base Tidepool API datum
- Initial CGM and Food datum types
- Add association, dictionary, location, and origin common structs
- Add blood glucose constants and target structs
- Add profile and contained patient structs
- Add dataset struct
- Updates to example app to reflect TAPI changes
- Add sharing to example app for debugging purposes
- Add sample data
- Refactor errors to capture all specific conditions
- Refactor request create and perform request to utilize Codable
- Replace all usage RawRepresentation with Codable
- Loads of tests