### PR TITLE
[LOOP-1274] Fetch prescription from Tidepool backend

### DIFF
--- a/TidepoolKit.xcodeproj/project.pbxproj
+++ b/TidepoolKit.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		A9116AE224083C1100483021 /* TDataSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116AE024083C1100483021 /* TDataSet.swift */; };
 		A9116AF32409D8C400483021 /* TDatum.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116AF12409D8C400483021 /* TDatum.swift */; };
 		A9116AF62409D8E000483021 /* DataResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116AF52409D8E000483021 /* DataResponse.swift */; };
+		A918695426388E4A00532575 /* TPrescriptionClaim.swift in Sources */ = {isa = PBXBuildFile; fileRef = A918695326388E4A00532575 /* TPrescriptionClaim.swift */; };
 		A9285746262B920E00AC3460 /* LoginSignupNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9285745262B920E00AC3460 /* LoginSignupNavigationController.swift */; };
 		A9285750262B923700AC3460 /* LoginSignupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A928574F262B923700AC3460 /* LoginSignupViewModel.swift */; };
 		A9285756262B926B00AC3460 /* LoginSignupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9285755262B926B00AC3460 /* LoginSignupView.swift */; };
@@ -91,6 +92,8 @@
 		A945A58424141B6D002FB575 /* TApplicationSettingsDatumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A945A58324141B6D002FB575 /* TApplicationSettingsDatumTests.swift */; };
 		A94D7D4323E242D60087A9C0 /* Locked.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94D7D4223E242D60087A9C0 /* Locked.swift */; };
 		A94D7D4523E243780087A9C0 /* UnfairLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94D7D4423E243780087A9C0 /* UnfairLock.swift */; };
+		A951B304263C6B7D00926CB4 /* TPrescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A951B303263C6B7D00926CB4 /* TPrescriptionTests.swift */; };
+		A951B30E263C6B8900926CB4 /* TPrescriptionClaimTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A951B30D263C6B8900926CB4 /* TPrescriptionClaimTests.swift */; };
 		A96633DE2409E99F007B68C1 /* TFoodDatum.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96633C22409E99F007B68C1 /* TFoodDatum.swift */; };
 		A96633E32409E99F007B68C1 /* TCBGDatum.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96633C82409E99F007B68C1 /* TCBGDatum.swift */; };
 		A973CD2323D68B6400C44032 /* TLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = A973CD2223D68B6400C44032 /* TLogging.swift */; };
@@ -101,6 +104,7 @@
 		A973CD3123D6916C00C44032 /* TidepoolKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A943535023C932A10093CFA3 /* TidepoolKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A973CD3423D6916C00C44032 /* TidepoolKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A943536F23C932BF0093CFA3 /* TidepoolKitUI.framework */; };
 		A973CD3523D6916C00C44032 /* TidepoolKitUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A943536F23C932BF0093CFA3 /* TidepoolKitUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A98144602632236C003CE039 /* TPrescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = A981445F2632236C003CE039 /* TPrescription.swift */; };
 		A98780B8240A0D5E0007D5E1 /* TOriginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9878093240A0D5E0007D5E1 /* TOriginTests.swift */; };
 		A98780B9240A0D5E0007D5E1 /* TAsssociationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9878094240A0D5E0007D5E1 /* TAsssociationTests.swift */; };
 		A98780BA240A0D5E0007D5E1 /* TBloodGlucoseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9878095240A0D5E0007D5E1 /* TBloodGlucoseTests.swift */; };
@@ -148,6 +152,7 @@
 		A9DCED15262779290057359F /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DCED13262779290057359F /* LocalizedString.swift */; };
 		A9DCED1B2627792F0057359F /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DCED1A2627792F0057359F /* Image.swift */; };
 		A9DCED21262779350057359F /* ContentPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DCED20262779350057359F /* ContentPreview.swift */; };
+		A9E33AA126444DC200B8D280 /* WeakSynchronizedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E33AA026444DC200B8D280 /* WeakSynchronizedSet.swift */; };
 		A9EAB8E823DFC77E00874D2A /* DNS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EAB8E723DFC77E00874D2A /* DNS.swift */; };
 /* End PBXBuildFile section */
 
@@ -244,6 +249,7 @@
 		A9116AE024083C1100483021 /* TDataSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TDataSet.swift; sourceTree = "<group>"; };
 		A9116AF12409D8C400483021 /* TDatum.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TDatum.swift; sourceTree = "<group>"; };
 		A9116AF52409D8E000483021 /* DataResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataResponse.swift; sourceTree = "<group>"; };
+		A918695326388E4A00532575 /* TPrescriptionClaim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPrescriptionClaim.swift; sourceTree = "<group>"; };
 		A9285745262B920E00AC3460 /* LoginSignupNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSignupNavigationController.swift; sourceTree = "<group>"; };
 		A928574F262B923700AC3460 /* LoginSignupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSignupViewModel.swift; sourceTree = "<group>"; };
 		A9285755262B926B00AC3460 /* LoginSignupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSignupView.swift; sourceTree = "<group>"; };
@@ -325,11 +331,14 @@
 		A945A58324141B6D002FB575 /* TApplicationSettingsDatumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TApplicationSettingsDatumTests.swift; sourceTree = "<group>"; };
 		A94D7D4223E242D60087A9C0 /* Locked.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locked.swift; sourceTree = "<group>"; };
 		A94D7D4423E243780087A9C0 /* UnfairLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnfairLock.swift; sourceTree = "<group>"; };
+		A951B303263C6B7D00926CB4 /* TPrescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPrescriptionTests.swift; sourceTree = "<group>"; };
+		A951B30D263C6B8900926CB4 /* TPrescriptionClaimTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPrescriptionClaimTests.swift; sourceTree = "<group>"; };
 		A96633C22409E99F007B68C1 /* TFoodDatum.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TFoodDatum.swift; sourceTree = "<group>"; };
 		A96633C82409E99F007B68C1 /* TCBGDatum.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TCBGDatum.swift; sourceTree = "<group>"; };
 		A973CD2223D68B6400C44032 /* TLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLogging.swift; sourceTree = "<group>"; };
 		A973CD2623D68FC300C44032 /* TAPI+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TAPI+UI.swift"; sourceTree = "<group>"; };
 		A973CD2823D68FE000C44032 /* TAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAPI.swift; sourceTree = "<group>"; };
+		A981445F2632236C003CE039 /* TPrescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPrescription.swift; sourceTree = "<group>"; };
 		A9878093240A0D5E0007D5E1 /* TOriginTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TOriginTests.swift; sourceTree = "<group>"; };
 		A9878094240A0D5E0007D5E1 /* TAsssociationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TAsssociationTests.swift; sourceTree = "<group>"; };
 		A9878095240A0D5E0007D5E1 /* TBloodGlucoseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TBloodGlucoseTests.swift; sourceTree = "<group>"; };
@@ -377,6 +386,7 @@
 		A9DCED13262779290057359F /* LocalizedString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalizedString.swift; sourceTree = "<group>"; };
 		A9DCED1A2627792F0057359F /* Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		A9DCED20262779350057359F /* ContentPreview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentPreview.swift; sourceTree = "<group>"; };
+		A9E33AA026444DC200B8D280 /* WeakSynchronizedSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakSynchronizedSet.swift; sourceTree = "<group>"; };
 		A9EAB8E723DFC77E00874D2A /* DNS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNS.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -643,10 +653,20 @@
 				A9EAB8E723DFC77E00874D2A /* DNS.swift */,
 				A94D7D4223E242D60087A9C0 /* Locked.swift */,
 				A94D7D4423E243780087A9C0 /* UnfairLock.swift */,
+				A9E33AA026444DC200B8D280 /* WeakSynchronizedSet.swift */,
 				A99491D223FE1F0F00865738 /* Extensions */,
 				A9C57C4E23FF668300A5964D /* Responses */,
 			);
 			path = Internal;
+			sourceTree = "<group>";
+		};
+		A951B302263C6B6500926CB4 /* Prescription */ = {
+			isa = PBXGroup;
+			children = (
+				A951B30D263C6B8900926CB4 /* TPrescriptionClaimTests.swift */,
+				A951B303263C6B7D00926CB4 /* TPrescriptionTests.swift */,
+			);
+			path = Prescription;
 			sourceTree = "<group>";
 		};
 		A973CD2A23D6916300C44032 /* Frameworks */ = {
@@ -654,6 +674,15 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		A981445E26322350003CE039 /* Prescription */ = {
+			isa = PBXGroup;
+			children = (
+				A981445F2632236C003CE039 /* TPrescription.swift */,
+				A918695326388E4A00532575 /* TPrescriptionClaim.swift */,
+			);
+			path = Prescription;
 			sourceTree = "<group>";
 		};
 		A9878092240A0D5E0007D5E1 /* Model */ = {
@@ -668,6 +697,7 @@
 				A9878093240A0D5E0007D5E1 /* TOriginTests.swift */,
 				A9BF06D1240EEC87005D5337 /* TProfileTests.swift */,
 				A9878097240A0D5E0007D5E1 /* Datum */,
+				A951B302263C6B6500926CB4 /* Prescription */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -765,6 +795,7 @@
 				A9C57BFF23FF3BFD00A5964D /* TOrigin.swift */,
 				A9C57C582400B76000A5964D /* TProfile.swift */,
 				A9116AE424083C4C00483021 /* Datum */,
+				A981445E26322350003CE039 /* Prescription */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1077,6 +1108,7 @@
 				A945A58224141B55002FB575 /* TApplicationSettingsDatum.swift in Sources */,
 				A930763D241224C700D1E376 /* TNormalBolusDatum.swift in Sources */,
 				A994916923FB4CF500865738 /* TEnvironment.swift in Sources */,
+				A98144602632236C003CE039 /* TPrescription.swift in Sources */,
 				A9C57C2823FF3BFD00A5964D /* TLocation.swift in Sources */,
 				A9DA2ABB2413093C0083298B /* TDosingDecisionDatum.swift in Sources */,
 				A94300CA2416E63000DDFAD4 /* TInsulin.swift in Sources */,
@@ -1112,8 +1144,10 @@
 				A9307643241224C700D1E376 /* TWaterDatum.swift in Sources */,
 				A973CD2923D68FE000C44032 /* TAPI.swift in Sources */,
 				A9307633241224C700D1E376 /* TReservoirChangeDeviceEventDatum.swift in Sources */,
+				A9E33AA126444DC200B8D280 /* WeakSynchronizedSet.swift in Sources */,
 				A9C57C592400B76000A5964D /* TProfile.swift in Sources */,
 				A930763F241224C700D1E376 /* TBasalDatum.swift in Sources */,
+				A918695426388E4A00532575 /* TPrescriptionClaim.swift in Sources */,
 				A9307637241224C700D1E376 /* TTimeChangeDeviceEventDatum.swift in Sources */,
 				A9307630241224C700D1E376 /* TReportedStateDatum.swift in Sources */,
 			);
@@ -1151,6 +1185,7 @@
 				A9BF06E4240F3051005D5337 /* JSONDecoderTests.swift in Sources */,
 				A930766D241224F800D1E376 /* TAlarmDeviceEventDatumTests.swift in Sources */,
 				A930766A241224F800D1E376 /* TTimeChangeDeviceEventDatumTests.swift in Sources */,
+				A951B304263C6B7D00926CB4 /* TPrescriptionTests.swift in Sources */,
 				A930767A241224F800D1E376 /* TNormalBolusDatumTests.swift in Sources */,
 				A9307669241224F800D1E376 /* TStatusDeviceEventDatumTests.swift in Sources */,
 				A9307666241224F800D1E376 /* TReportedStateDatumTests.swift in Sources */,
@@ -1165,6 +1200,7 @@
 				A9307678241224F800D1E376 /* TCGMSettingsDatumTests.swift in Sources */,
 				A9BF06D2240EEC87005D5337 /* TProfileTests.swift in Sources */,
 				A9DA2ABF24130D050083298B /* TPumpStatusDatumTests.swift in Sources */,
+				A951B30E263C6B8900926CB4 /* TPrescriptionClaimTests.swift in Sources */,
 				A930766F241224F800D1E376 /* TSuspendedBasalDatumTests.swift in Sources */,
 				A9307677241224F800D1E376 /* TPhysicalActivityDatumTests.swift in Sources */,
 				A98780BD240A0D5E0007D5E1 /* TFoodDatumTests.swift in Sources */,

--- a/TidepoolKit/Internal/Extensions/TimeInterval.swift
+++ b/TidepoolKit/Internal/Extensions/TimeInterval.swift
@@ -9,17 +9,109 @@
 import Foundation
 
 extension TimeInterval {
+    static let day = days(1)
+    static let hour = hours(1)
+    static let minute = minutes(1)
+    static let second = seconds(1)
     static let millisecond = milliseconds(1)
 
-    static func milliseconds(_ milliseconds: Double) -> TimeInterval {
-        return self.init(milliseconds: milliseconds)
+    static func days(_ days: Double) -> Self {
+        return Self(days: days)
+    }
+
+    static func days(_ days: Int) -> Self {
+        return Self(days: days)
+    }
+
+    static func hours(_ hours: Double) -> Self {
+        return Self(hours: hours)
+    }
+
+    static func hours(_ hours: Int) -> Self {
+        return Self(hours: hours)
+    }
+
+    static func minutes(_ minutes: Double) -> Self {
+        return Self(minutes: minutes)
+    }
+
+    static func minutes(_ minutes: Int) -> Self {
+        return Self(minutes: minutes)
+    }
+
+    static func seconds(_ seconds: Double) -> Self {
+        return Self(seconds: seconds)
+    }
+
+    static func seconds(_ seconds: Int) -> Self {
+        return Self(seconds: seconds)
+    }
+
+    static func milliseconds(_ milliseconds: Double) -> Self {
+        return Self(milliseconds: milliseconds)
+    }
+
+    static func milliseconds(_ milliseconds: Int) -> Self {
+        return Self(milliseconds: milliseconds)
+    }
+
+    init(days: Double) {
+        self.init(hours: days * 24)
+    }
+
+    init(days: Int) {
+        self.init(hours: days * 24)
+    }
+
+    init(hours: Double) {
+        self.init(minutes: hours * 60)
+    }
+
+    init(hours: Int) {
+        self.init(minutes: hours * 60)
+    }
+
+    init(minutes: Double) {
+        self.init(seconds: minutes * 60)
+    }
+
+    init(minutes: Int) {
+        self.init(seconds: minutes * 60)
+    }
+
+    init(seconds: Double) {
+        self.init(seconds)
+    }
+
+    init(seconds: Int) {
+        self.init(seconds)
     }
 
     init(milliseconds: Double) {
-        self.init(milliseconds / 1000)
+        self.init(seconds: milliseconds / 1000)
+    }
+
+    init(milliseconds: Int) {
+        self.init(seconds: Double(milliseconds) / 1000)
+    }
+
+    var days: Double {
+        return hours / 24
+    }
+
+    var hours: Double {
+        return minutes / 60
+    }
+
+    var minutes: Double {
+        return seconds / 60
+    }
+
+    var seconds: Double {
+        return self
     }
 
     var milliseconds: Double {
-        return self * 1000
+        return seconds * 1000
     }
 }

--- a/TidepoolKit/Internal/WeakSynchronizedSet.swift
+++ b/TidepoolKit/Internal/WeakSynchronizedSet.swift
@@ -1,0 +1,147 @@
+//
+//  WeakSynchronizedSet.swift
+//  TidepoolKit
+//
+//  Created by Michael Pangburn
+//  Copyright © 2019 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+
+/// A set-like collection of weak types, providing closure-based iteration on a client-specified queue
+/// Mutations and iterations are thread-safe
+public class WeakSynchronizedSet<Element> {
+    private typealias Identifier = ObjectIdentifier
+    private typealias ElementContainer = ElementDispatchContainer<Element>
+
+    private class ElementDispatchContainer<Element> {
+        private weak var _element: AnyObject?
+        weak var queue: DispatchQueue?
+
+        var element: Element? {
+            return _element as? Element
+        }
+
+        init(element: Element, queue: DispatchQueue) {
+            // All Swift values are implicitly convertible to `AnyObject`,
+            // so this runtime check is the tradeoff for supporting class-constrained protocol types.
+            precondition(Mirror(reflecting: element).displayStyle == .class, "Weak references can only be held of class types.")
+
+            self._element = element as AnyObject
+            self.queue = queue
+        }
+
+        func call(_ body: @escaping (_ element: Element) -> Void) {
+            guard let queue = self.queue, let element = self.element else {
+                return
+            }
+
+            queue.async {
+                body(element)
+            }
+        }
+    }
+
+    private let elements: Locked<[Identifier: ElementContainer]>
+
+    public init() {
+        elements = Locked([:])
+    }
+
+    /// Adds an element and its calling queue
+    ///
+    /// - Parameters:
+    ///   - element: The element
+    ///   - queue: The queue to use when performing calls with the element
+    public func insert(_ element: Element, queue: DispatchQueue) {
+        insert(ElementDispatchContainer(element: element, queue: queue))
+    }
+
+    /// Prunes any element references that have been deallocated
+    /// - Returns: A reference to the instance for easy chaining
+    @discardableResult public func cleanupDeallocatedElements() -> Self {
+        elements.mutate { (storage) in
+            for (id, element) in storage where element.element == nil {
+                storage.removeValue(forKey: id)
+            }
+        }
+        return self
+    }
+
+    /// Whether the element is in the set
+    ///
+    /// - Parameter element: The element
+    /// - Returns: True if the element is in the set
+    public func contains(_ element: Element) -> Bool {
+        let id = identifier(for: element)
+        return elements.value[id] != nil
+    }
+
+    /// The total number of element in the set
+    ///
+    /// Deallocated references are counted, so calling `cleanupDeallocatedElements` is advised to maintain accuracy of this value
+    public var count: Int {
+        return elements.value.count
+    }
+
+    /// Calls the given closure on each element in the set, on the queue specified when the element was added
+    ///
+    /// The order of calls is not defined
+    ///
+    /// - Parameter body: The closure to execute
+    public func forEach(_ body: @escaping (Element) -> Void) {
+        // Hold the lock while we iterate, since each call is dispatched out
+        elements.mutate { (elements) in
+            elements.forEach { (pair) in
+                pair.value.call(body)
+            }
+        }
+    }
+
+    /// Removes the specified element from the set
+    ///
+    /// - Parameter element: The element
+    public func removeElement(_ element: Element) {
+        removeValue(forKey: identifier(for: element))
+    }
+}
+
+extension WeakSynchronizedSet {
+    private func identifier(for element: Element) -> ObjectIdentifier {
+        return ObjectIdentifier(element as AnyObject)
+    }
+
+    private func identifier(for elementContainer: ElementContainer) -> ObjectIdentifier? {
+        guard let element = elementContainer.element else {
+            return nil
+        }
+        return identifier(for: element)
+    }
+
+    @discardableResult
+    private func insert(_ newMember: ElementContainer) -> (inserted: Bool, memberAfterInsert: ElementContainer?) {
+        guard let id = identifier(for: newMember) else {
+            return (inserted: false, memberAfterInsert: nil)
+        }
+        var result: (inserted: Bool, memberAfterInsert: ElementContainer?)!
+        elements.mutate { (storage) in
+            if let existingMember = storage[id] {
+                result = (inserted: false, memberAfterInsert: existingMember)
+            } else {
+                storage[id] = newMember
+                result = (inserted: true, memberAfterInsert: newMember)
+            }
+        }
+        return result
+    }
+
+    @discardableResult
+    private func removeValue(forKey key: Identifier) -> ElementContainer? {
+        var previousMember: ElementContainer?
+        elements.mutate { (storage) in
+            previousMember = storage.removeValue(forKey: key)
+        }
+        return previousMember
+    }
+}

--- a/TidepoolKit/Internal/WeakSynchronizedSet.swift
+++ b/TidepoolKit/Internal/WeakSynchronizedSet.swift
@@ -11,7 +11,7 @@ import Foundation
 
 /// A set-like collection of weak types, providing closure-based iteration on a client-specified queue
 /// Mutations and iterations are thread-safe
-public class WeakSynchronizedSet<Element> {
+class WeakSynchronizedSet<Element> {
     private typealias Identifier = ObjectIdentifier
     private typealias ElementContainer = ElementDispatchContainer<Element>
 

--- a/TidepoolKit/Model/Prescription/TPrescription.swift
+++ b/TidepoolKit/Model/Prescription/TPrescription.swift
@@ -1,0 +1,232 @@
+//
+//  TPrescription.swift
+//  TidepoolKit
+//
+//  Created by Darin Krauss on 4/22/21.
+//  Copyright © 2021 Tidepool Project. All rights reserved.
+//
+
+public struct TPrescription: Codable, Equatable {
+    public var id: String?
+    public var patientUserId: String?
+    public var accessCode: String?
+    public var state: State?
+    public var latestRevision: Revision?
+    public var expirationTime: Date?
+    public var prescriberUserId: String?
+    public var createdTime: Date?
+    public var createdUserId: String?
+    public var modifiedTime: Date?
+    public var modifiedUserId: String?
+    
+    public init(id: String? = nil,
+                patientUserId: String? = nil,
+                accessCode: String? = nil,
+                state: State? = nil,
+                latestRevision: Revision? = nil,
+                expirationTime: Date? = nil,
+                prescriberUserId: String? = nil,
+                createdTime: Date? = nil,
+                createdUserId: String? = nil,
+                modifiedTime: Date? = nil,
+                modifiedUserId: String? = nil) {
+        self.id = id
+        self.patientUserId = patientUserId
+        self.accessCode = accessCode
+        self.state = state
+        self.latestRevision = latestRevision
+        self.expirationTime = expirationTime
+        self.prescriberUserId = prescriberUserId
+        self.createdTime = createdTime
+        self.createdUserId = createdUserId
+        self.modifiedTime = modifiedTime
+        self.modifiedUserId = modifiedUserId
+    }
+    
+    public enum State: String, Codable, Equatable {
+        case draft
+        case pending
+        case submitted
+        case claimed
+        case expired
+        case active
+        case inactive
+    }
+    
+    public struct Revision: Codable, Equatable {
+        public var revisionId: Int?
+        public var attributes: Attributes?
+        
+        public init(revisionId: Int? = nil, attributes: Attributes? = nil) {
+            self.revisionId = revisionId
+            self.attributes = attributes
+        }
+    }
+    
+    public struct Attributes: Codable, Equatable {
+        public var accountType: AccountType?
+        public var caregiverFirstName: String?
+        public var caregiverLastName: String?
+        public var firstName: String?
+        public var lastName: String?
+        public var birthday: String?
+        public var mrn: String?
+        public var email: String?
+        public var sex: Sex?
+        public var weight: Weight?
+        public var yearOfDiagnosis: Int?
+        public var phoneNumber: PhoneNumber?
+        public var initialSettings: InitialSettings?
+        public var training: Training?
+        public var therapySettings: TherapySettings?
+        public var prescriberTermsAccepted: Bool?
+        public var state: State?
+        public var createdTime: Date?
+        public var createdUserId: String?
+        
+        public init(accountType: AccountType? = nil,
+                    caregiverFirstName: String? = nil,
+                    caregiverLastName: String? = nil,
+                    firstName: String? = nil,
+                    lastName: String? = nil,
+                    birthday: String? = nil,
+                    mrn: String? = nil,
+                    email: String? = nil,
+                    sex: Sex? = nil,
+                    weight: Weight? = nil,
+                    yearOfDiagnosis: Int? = nil,
+                    phoneNumber: PhoneNumber? = nil,
+                    initialSettings: InitialSettings? = nil,
+                    training: Training? = nil,
+                    therapySettings: TherapySettings? = nil,
+                    prescriberTermsAccepted: Bool? = nil,
+                    state: State? = nil,
+                    createdTime: Date? = nil,
+                    createdUserId: String? = nil) {
+            self.accountType = accountType
+            self.caregiverFirstName = caregiverFirstName
+            self.caregiverLastName = caregiverLastName
+            self.firstName = firstName
+            self.lastName = lastName
+            self.birthday = birthday
+            self.mrn = mrn
+            self.email = email
+            self.sex = sex
+            self.weight = weight
+            self.yearOfDiagnosis = yearOfDiagnosis
+            self.phoneNumber = phoneNumber
+            self.initialSettings = initialSettings
+            self.training = training
+            self.therapySettings = therapySettings
+            self.prescriberTermsAccepted = prescriberTermsAccepted
+            self.state = state
+            self.createdTime = createdTime
+            self.createdUserId = createdUserId
+        }
+        
+        public enum State: String, Codable, Equatable {
+            case draft
+            case pending
+            case submitted
+        }
+    }
+    
+    public enum AccountType: String, Codable, Equatable {
+        case patient
+        case caregiver
+    }
+    
+    public enum Sex: String, Codable, Equatable {
+        case male
+        case female
+        case undisclosed
+    }
+    
+    public struct Weight: Codable, Equatable {
+        public var value: Double?
+        public var units: Units?
+        
+        public init(value: Double? = nil, units: Units? = nil) {
+            self.value = value
+            self.units = units
+        }
+        
+        public enum Units: String, Codable, Equatable {
+            case kg
+        }
+    }
+    
+    public struct PhoneNumber: Codable, Equatable {
+        public var countryCode: Int?
+        public var number: String?
+        
+        public init(countryCode: Int? = nil, number: String? = nil) {
+            self.countryCode = countryCode
+            self.number = number
+        }
+    }
+    
+    public struct InitialSettings: Codable, Equatable {
+        public var bloodGlucoseUnits: BloodGlucoseUnits?
+        public var basalRateSchedule: [BasalRateStart]?
+        public var bloodGlucoseTargetPhysicalActivity: BloodGlucoseTarget?
+        public var bloodGlucoseTargetPreprandial: BloodGlucoseTarget?
+        public var bloodGlucoseTargetSchedule: [BloodGlucoseStartTarget]?
+        public var carbohydrateRatioSchedule: [CarbohydrateRatioStart]?
+        public var glucoseSafetyLimit: Double?
+        public var insulinModel: InsulinModelType?
+        public var insulinSensitivitySchedule: [InsulinSensitivityStart]?
+        public var basalRateMaximum: BasalRateMaximum?
+        public var bolusAmountMaximum: BolusAmountMaximum?
+        public var pumpId: String?
+        public var cgmId: String?
+        
+        public init(bloodGlucoseUnits: BloodGlucoseUnits? = nil,
+                    basalRateSchedule: [BasalRateStart]? = nil,
+                    bloodGlucoseTargetPhysicalActivity: BloodGlucoseTarget? = nil,
+                    bloodGlucoseTargetPreprandial: BloodGlucoseTarget? = nil,
+                    bloodGlucoseTargetSchedule: [BloodGlucoseStartTarget]? = nil,
+                    carbohydrateRatioSchedule: [CarbohydrateRatioStart]? = nil,
+                    glucoseSafetyLimit: Double? = nil,
+                    insulinModel: InsulinModelType? = nil,
+                    insulinSensitivitySchedule: [InsulinSensitivityStart]? = nil,
+                    basalRateMaximum: BasalRateMaximum? = nil,
+                    bolusAmountMaximum: BolusAmountMaximum? = nil,
+                    pumpId: String? = nil,
+                    cgmId: String? = nil) {
+            self.bloodGlucoseUnits = bloodGlucoseUnits
+            self.basalRateSchedule = basalRateSchedule
+            self.bloodGlucoseTargetPhysicalActivity = bloodGlucoseTargetPhysicalActivity
+            self.bloodGlucoseTargetPreprandial = bloodGlucoseTargetPreprandial
+            self.bloodGlucoseTargetSchedule = bloodGlucoseTargetSchedule
+            self.carbohydrateRatioSchedule = carbohydrateRatioSchedule
+            self.glucoseSafetyLimit = glucoseSafetyLimit
+            self.insulinModel = insulinModel
+            self.insulinSensitivitySchedule = insulinSensitivitySchedule
+            self.basalRateMaximum = basalRateMaximum
+            self.bolusAmountMaximum = bolusAmountMaximum
+            self.pumpId = pumpId
+            self.cgmId = cgmId
+        }
+    }
+    
+    public enum Training: String, Codable, Equatable {
+        case inPerson
+        case inModule
+    }
+    
+    public enum TherapySettings: String, Codable, Equatable {
+        case initial
+        case transferPumpSettings
+    }
+    
+    public typealias BloodGlucoseUnits = TBloodGlucose.Units
+    public typealias BasalRateStart = TPumpSettingsDatum.BasalRateStart
+    public typealias BloodGlucoseTarget = TBloodGlucose.Target
+    public typealias BloodGlucoseStartTarget = TBloodGlucose.StartTarget
+    public typealias CarbohydrateRatioStart = TPumpSettingsDatum.CarbohydrateRatioStart
+    public typealias InsulinModelType = TPumpSettingsDatum.InsulinModel.ModelType
+    public typealias InsulinSensitivityStart = TPumpSettingsDatum.InsulinSensitivityStart
+    public typealias BasalRateMaximum = TPumpSettingsDatum.Basal.RateMaximum
+    public typealias BolusAmountMaximum = TPumpSettingsDatum.Bolus.AmountMaximum
+}

--- a/TidepoolKit/Model/Prescription/TPrescriptionClaim.swift
+++ b/TidepoolKit/Model/Prescription/TPrescriptionClaim.swift
@@ -1,0 +1,17 @@
+//
+//  TPrescriptionClaim.swift
+//  TidepoolKit
+//
+//  Created by Darin Krauss on 4/27/21.
+//  Copyright © 2021 Tidepool Project. All rights reserved.
+//
+
+public struct TPrescriptionClaim: Codable, Equatable {
+    public var accessCode: String
+    public var birthday: String
+    
+    public init(accessCode: String, birthday: String) {
+        self.accessCode = accessCode
+        self.birthday = birthday
+    }
+}

--- a/TidepoolKit/TAPI.swift
+++ b/TidepoolKit/TAPI.swift
@@ -8,6 +8,16 @@
 
 import Foundation
 
+/// Observer of the Tidepool API
+public protocol TAPIObserver: AnyObject {
+
+    /// Informs the observer that the API updated the session.
+    ///
+    /// - Parameters:
+    ///     - session: The session.
+    func apiDidUpdateSession(_ session: TSession?)
+}
+
 /// The Tidepool API
 public class TAPI {
 
@@ -28,17 +38,49 @@ public class TAPI {
         }
     }
 
+    /// The session used for all requests.
+    public var session: TSession? {
+        get {
+            return sessionLocked.value
+        }
+        set {
+            sessionLocked.mutate { $0 = newValue }
+            observers.forEach { $0.apiDidUpdateSession(newValue) }
+        }
+    }
+
+    private var observers = WeakSynchronizedSet<TAPIObserver>()
+
     /// Create a new instance of TAPI. Automatically lookup additional environments in the background.
     ///
     /// - Parameters:
+    ///   - session: The initial session to use, if any.
     ///   - automaticallyFetchEnvironments: Automatically fetch an updated list of environments when created.
-    public init(automaticallyFetchEnvironments: Bool = true) {
+    public init(session: TSession? = nil, automaticallyFetchEnvironments: Bool = true) {
         self.environmentsLocked = Locked(TAPI.defaultEnvironments)
         self.urlSessionConfigurationLocked = Locked(TAPI.defaultURLSessionConfiguration)
         self.urlSessionLocked = Locked(nil)
+        self.sessionLocked = Locked(session)
         if automaticallyFetchEnvironments {
             fetchEnvironments()
         }
+    }
+
+    /// Start observing the API.
+    ///
+    /// - Parameters:
+    ///     - observer: The observer observing the API.
+    ///     - queue: The Dispatch queue upon which to notify the observer of API changes.
+    public func addObserver(_ observer: TAPIObserver, queue: DispatchQueue = .main) {
+        observers.insert(observer, queue: queue)
+    }
+
+    /// Stop observing the API.
+    ///
+    /// - Parameters:
+    ///     - observer: The observer observing the API.
+    public func removeObserver(_ observer: TAPIObserver) {
+        observers.removeElement(observer)
     }
 
     // MARK: - Environment
@@ -80,28 +122,29 @@ public class TAPI {
     ///   - environment: The environment to login.
     ///   - email: The email to use for login.
     ///   - password: The password to use for login.
-    ///   - completion: The completion function to invoke with the newly created session or an error.
-    public func login(environment: TEnvironment, email: String, password: String, completion: @escaping (Result<TSession, TError>) -> Void) {
+    ///   - completion: The completion function to invoke with any error.
+    public func login(environment: TEnvironment, email: String, password: String, completion: @escaping (TError?) -> Void) {
         var request = createRequest(environment: environment, method: "POST", path: "/auth/login")
         request?.setValue(basicAuthorizationFromCredentials(email: email, password: password), forHTTPHeaderField: HTTPHeaderField.authorization.rawValue)
-        performRequest(request) { (result: DecodableHTTPResult<LoginResponse>) -> Void in
+        performRequest(request, allowSessionRefresh: false) { (result: DecodableHTTPResult<LoginResponse>) -> Void in
             switch result {
             case .failure(let error):
                 switch error {
                 case .requestNotAuthorized(let response, let data):     // CUSTOM: Backend currently returns status code 403 to imply email not verified
-                    completion(.failure(.requestEmailNotVerified(response, data)))
+                    completion(.requestEmailNotVerified(response, data))
                 default:
-                    completion(.failure(error))
+                    completion(error)
                 }
             case .success((let response, let data, let loginResponse)):
                 if let authenticationToken = response.value(forHTTPHeaderField: "X-Tidepool-Session-Token"), !authenticationToken.isEmpty {
                     if loginResponse.termsAccepted?.isEmpty == false {     // CUSTOM: Backend does not currently explicitly check if terms are accepted
-                        completion(.success(TSession(environment: environment, authenticationToken: authenticationToken, userId: loginResponse.userId)))
+                        self.session = TSession(environment: environment, authenticationToken: authenticationToken, userId: loginResponse.userId)
+                        completion(nil)
                     } else {
-                        completion(.failure(.requestTermsOfServiceNotAccepted(response, data)))
+                        completion(.requestTermsOfServiceNotAccepted(response, data))
                     }
                 } else {
-                    completion(.failure(.responseNotAuthenticated(response, data)))
+                    completion(.responseNotAuthenticated(response, data))
                 }
             }
         }
@@ -112,40 +155,55 @@ public class TAPI {
         return "Basic \(encodedCredentials)"
     }
 
-    /// Refresh the given Tidepool API session. If successful, the completion handler should replace
-    /// the old session with the new session. Upon failure, the completion handler should forget the
-    /// old session.
+    /// Refresh the Tidepool API session.
     ///
-    /// An .unauthenticated error indicates that the old session is no longer valid. All other errors
+    /// An .requestNotAuthenticated error indicates that the old session is no longer valid. All other errors
     /// indicate that the old session is still valid and refresh can be retried.
     ///
     /// - Parameters:
-    ///   - session: The Tidepool API session to refresh.
-    ///   - completion: The completion function to invoke with the updated session or any error.
-    public func refresh(session: TSession, completion: @escaping (Result<TSession, TError>) -> Void) {
-        let request = createRequest(session: session, method: "GET", path: "/auth/login")
-        performRequest(request) { (result: HTTPResult) -> Void in
+    ///   - completion: The completion function to invoke with any error.
+    public func refreshSession(completion: @escaping (TError?) -> Void) {
+        guard let session = session else {
+            completion(.sessionMissing)
+            return
+        }
+
+        let request = createRequest(method: "GET", path: "/auth/login")
+        performRequest(request, allowSessionRefresh: false) { (result: HTTPResult) -> Void in
             switch result {
             case .failure(let error):
-                completion(.failure(error))
+                if case .requestNotAuthenticated = error {
+                    self.session = nil
+                }
+                completion(error)
             case .success((let response, let data)):
                 if let authenticationToken = response.value(forHTTPHeaderField: "X-Tidepool-Session-Token"), !authenticationToken.isEmpty {
-                    completion(.success(TSession(environment: session.environment, authenticationToken: authenticationToken, userId: session.userId, trace: session.trace)))
+                    self.session = TSession(session: session, authenticationToken: authenticationToken)
+                    completion(nil)
                 } else {
-                    completion(.failure(.responseNotAuthenticated(response, data)))
+                    completion(.responseNotAuthenticated(response, data))
                 }
             }
         }
     }
 
-    /// Logout the given Tidepool API session. The completion handler should forget the old session.
+    /// Logout the Tidepool API session.
     ///
     /// - Parameters:
-    ///   - session: The Tidepool API session to logout.
     ///   - completion: The completion function to invoke with any error.
-    public func logout(session: TSession, completion: @escaping (TError?) -> Void) {
-        let request = createRequest(session: session, method: "POST", path: "/auth/logout")
-        performRequest(request, completion: completion)
+    public func logout(completion: @escaping (TError?) -> Void) {
+        guard session != nil else {
+            completion(.sessionMissing)
+            return
+        }
+
+        let request = createRequest(method: "POST", path: "/auth/logout")
+        performRequest(request, allowSessionRefresh: false) { (error: TError?) -> Void in
+            if error == nil {
+                self.session = nil
+            }
+            completion(error)
+        }
     }
 
     // MARK: - Profile
@@ -154,10 +212,31 @@ public class TAPI {
     ///
     /// - Parameters:
     ///   - userId: The user id for which to get the profile. If no user id is specified, then the session user id is used.
-    ///   - session: The Tidepool API session to use.
     ///   - completion: The completion function to invoke with any error.
-    public func getProfile(userId: String? = nil, session: TSession, completion: @escaping (Result<TProfile, TError>) -> Void) {
-        let request = createRequest(session: session, method: "GET", path: "/metadata/\(userId ?? session.userId)/profile")
+    public func getProfile(userId: String? = nil, completion: @escaping (Result<TProfile, TError>) -> Void) {
+        guard let session = session else {
+            completion(.failure(.sessionMissing))
+            return
+        }
+
+        let request = createRequest(method: "GET", path: "/metadata/\(userId ?? session.userId)/profile")
+        performRequest(request, completion: completion)
+    }
+
+    // MARK: - Prescriptions
+
+    /// Claim the prescription for the session user id.
+    ///
+    /// - Parameters:
+    ///   - prescriptionClaim: The prescription claim to submit.
+    ///   - completion: The completion function to invoke with any error.
+    public func claimPrescription(prescriptionClaim: TPrescriptionClaim, completion: @escaping (Result<TPrescription, TError>) -> Void) {
+        guard session != nil else {
+            completion(.failure(.sessionMissing))
+            return
+        }
+
+        let request = createRequest(method: "POST", path: "/v1/prescriptions/claim", body: prescriptionClaim)
         performRequest(request, completion: completion)
     }
 
@@ -169,10 +248,14 @@ public class TAPI {
     /// - Parameters:
     ///   - filter: The filter to use when requesting the data sets.
     ///   - userId: The user id for which to get the data sets. If no user id is specified, then the session user id is used.
-    ///   - session: The Tidepool API session to use.
     ///   - completion: The completion function to invoke with any error.
-    public func listDataSets(filter: TDataSet.Filter? = nil, userId: String? = nil, session: TSession, completion: @escaping (Result<[TDataSet], TError>) -> Void) {
-        let request = createRequest(session: session, method: "GET", path: "/v1/users/\(userId ?? session.userId)/data_sets", queryItems: filter?.queryItems)
+    public func listDataSets(filter: TDataSet.Filter? = nil, userId: String? = nil, completion: @escaping (Result<[TDataSet], TError>) -> Void) {
+        guard let session = session else {
+            completion(.failure(.sessionMissing))
+            return
+        }
+
+        let request = createRequest(method: "GET", path: "/v1/users/\(userId ?? session.userId)/data_sets", queryItems: filter?.queryItems)
         performRequest(request, completion: completion)
     }
 
@@ -181,10 +264,14 @@ public class TAPI {
     /// - Parameters:
     ///   - dataSet: The data set to create.
     ///   - userId: The user id for which to create the data set. If no user id is specified, then the session user id is used.
-    ///   - session: The Tidepool API session to use.
     ///   - completion: The completion function to invoke with any error.
-    public func createDataSet(_ dataSet: TDataSet, userId: String? = nil, session: TSession, completion: @escaping (Result<TDataSet, TError>) -> Void) {
-        let request = createRequest(session: session, method: "POST", path: "/v1/users/\(userId ?? session.userId)/data_sets", body: dataSet)
+    public func createDataSet(_ dataSet: TDataSet, userId: String? = nil, completion: @escaping (Result<TDataSet, TError>) -> Void) {
+        guard let session = session else {
+            completion(.failure(.sessionMissing))
+            return
+        }
+
+        let request = createRequest(method: "POST", path: "/v1/users/\(userId ?? session.userId)/data_sets", body: dataSet)
         performRequest(request) { (result: DecodableResult<LegacyResponse.Success<TDataSet>>) -> Void in
             switch result {
             case .failure(let error):
@@ -206,10 +293,14 @@ public class TAPI {
     /// - Parameters:
     ///   - filter: The filter to use when requesting the data.
     ///   - userId: The user id for which to get the data. If no user id is specified, then the session user id is used.
-    ///   - session: The Tidepool API session to use.
     ///   - completion: The completion function to invoke with any error.
-    public func listData(filter: TDatum.Filter? = nil, userId: String? = nil, session: TSession, completion: @escaping (DataResult) -> Void) {
-        let request = createRequest(session: session, method: "GET", path: "/data/\(userId ?? session.userId)", queryItems: filter?.queryItems)
+    public func listData(filter: TDatum.Filter? = nil, userId: String? = nil, completion: @escaping (DataResult) -> Void) {
+        guard let session = session else {
+            completion(.failure(.sessionMissing))
+            return
+        }
+
+        let request = createRequest(method: "GET", path: "/data/\(userId ?? session.userId)", queryItems: filter?.queryItems)
         performRequest(request) { (result: DecodableResult<DataResponse>) -> Void in
             switch result {
             case .failure(let error):
@@ -225,15 +316,18 @@ public class TAPI {
     /// - Parameters:
     ///   - data: The data to create.
     ///   - dataSetId: The data set id for which to create the data.
-    ///   - session: The Tidepool API session to use.
     ///   - completion: The completion function to invoke with any error.
-    public func createData(_ data: [TDatum], dataSetId: String, session: TSession, completion: @escaping (TError?) -> Void) {
+    public func createData(_ data: [TDatum], dataSetId: String, completion: @escaping (TError?) -> Void) {
+        guard session != nil else {
+            completion(.sessionMissing)
+            return
+        }
         guard !data.isEmpty else {
             completion(nil)
             return
         }
 
-        let request = createRequest(session: session, method: "POST", path: "/v1/data_sets/\(dataSetId)/data", body: data)
+        let request = createRequest(method: "POST", path: "/v1/data_sets/\(dataSetId)/data", body: data)
         performRequest(request) { (result: DecodableResult<LegacyResponse.Success<DataResponse>>) -> Void in
             switch result {
             case .failure(let error):
@@ -260,22 +354,25 @@ public class TAPI {
     /// - Parameters:
     ///   - selectors: The selectors for the data to delete.
     ///   - dataSetId: The data set id from which to delete the data.
-    ///   - session: The Tidepool API session to use.
     ///   - completion: The completion function to invoke with any error.
-    public func deleteData(withSelectors selectors: [TDatum.Selector], dataSetId: String, session: TSession, completion: @escaping (TError?) -> Void) {
+    public func deleteData(withSelectors selectors: [TDatum.Selector], dataSetId: String, completion: @escaping (TError?) -> Void) {
+        guard session != nil else {
+            completion(.sessionMissing)
+            return
+        }
         guard !selectors.isEmpty else {
             completion(nil)
             return
         }
         
-        let request = createRequest(session: session, method: "DELETE", path: "/v1/data_sets/\(dataSetId)/data", body: selectors)
+        let request = createRequest(method: "DELETE", path: "/v1/data_sets/\(dataSetId)/data", body: selectors)
         performRequest(request, completion: completion)
     }
 
     // MARK: - Internal - Create Request
 
-    private func createRequest<E>(session: TSession, method: String, path: String, body: E) -> URLRequest? where E: Encodable {
-        var request = createRequest(session: session, method: method, path: path)
+    private func createRequest<E>(method: String, path: String, body: E) -> URLRequest? where E: Encodable {
+        var request = createRequest(method: method, path: path)
         request?.setValue("application/json; charset=utf-8", forHTTPHeaderField: HTTPHeaderField.contentType.rawValue)
         do {
             request?.httpBody = try JSONEncoder.tidepool.encode(body)
@@ -286,7 +383,11 @@ public class TAPI {
         return request
     }
 
-    private func createRequest(session: TSession, method: String, path: String, queryItems: [URLQueryItem]? = nil) -> URLRequest? {
+    private func createRequest(method: String, path: String, queryItems: [URLQueryItem]? = nil) -> URLRequest? {
+        guard let session = session else {
+            return nil
+        }
+
         var request = createRequest(environment: session.environment, method: method, path: path, queryItems: queryItems)
         request?.setValue(session.authenticationToken, forHTTPHeaderField: HTTPHeaderField.tidepoolSessionToken.rawValue)
         if let trace = session.trace {
@@ -309,8 +410,8 @@ public class TAPI {
 
     private typealias DecodableResult<D> = Result<D, TError> where D: Decodable
 
-    private func performRequest<D>(_ request: URLRequest?, completion: @escaping (DecodableResult<D>) -> Void) where D: Decodable {
-        performRequest(request) { (result: DecodableHTTPResult<D>) -> Void in
+    private func performRequest<D>(_ request: URLRequest?, allowSessionRefresh: Bool = true, completion: @escaping (DecodableResult<D>) -> Void) where D: Decodable {
+        performRequest(request, allowSessionRefresh: allowSessionRefresh) { (result: DecodableHTTPResult<D>) -> Void in
             switch result {
             case .failure(let error):
                 completion(.failure(error))
@@ -322,8 +423,8 @@ public class TAPI {
 
     private typealias DecodableHTTPResult<D> = Result<(HTTPURLResponse, Data, D), TError> where D: Decodable
 
-    private func performRequest<D>(_ request: URLRequest?, completion: @escaping (DecodableHTTPResult<D>) -> Void) where D: Decodable {
-        performRequest(request) { (result: HTTPResult) -> Void in
+    private func performRequest<D>(_ request: URLRequest?, allowSessionRefresh: Bool = true, completion: @escaping (DecodableHTTPResult<D>) -> Void) where D: Decodable {
+        performRequest(request, allowSessionRefresh: allowSessionRefresh) { (result: HTTPResult) -> Void in
             switch result {
             case .failure(let error):
                 completion(.failure(error))
@@ -341,8 +442,8 @@ public class TAPI {
         }
     }
 
-    private func performRequest(_ request: URLRequest?, completion: @escaping (TError?) -> Void) {
-        performRequest(request) { (result: HTTPResult) -> Void in
+    private func performRequest(_ request: URLRequest?, allowSessionRefresh: Bool = true, completion: @escaping (TError?) -> Void) {
+        performRequest(request, allowSessionRefresh: allowSessionRefresh) { (result: HTTPResult) -> Void in
             switch result {
             case .failure(let error):
                 completion(error)
@@ -354,7 +455,15 @@ public class TAPI {
 
     private typealias HTTPResult = Result<(HTTPURLResponse, Data?), TError>
 
-    private func performRequest(_ request: URLRequest?, completion: @escaping (HTTPResult) -> Void) {
+    private func performRequest(_ request: URLRequest?, allowSessionRefresh: Bool = true, completion: @escaping (HTTPResult) -> Void) {
+        if allowSessionRefresh, let session = session, session.wantsRefresh {
+            refreshSessionAndPerformRequest(request, completion: completion)
+        } else {
+            performRequest(request, allowSessionRefreshAfterFailure: allowSessionRefresh, completion: completion)
+        }
+    }
+
+    private func performRequest(_ request: URLRequest?, allowSessionRefreshAfterFailure: Bool, completion: @escaping (HTTPResult) -> Void) {
         guard let request = request else {
             completion(.failure(.requestInvalid))
             return
@@ -364,12 +473,34 @@ public class TAPI {
             if let error = error {
                 completion(.failure(.network(error)))
             } else if let response = response as? HTTPURLResponse {
-                completion(self.processStatusCode(response: response, data: data))
+                if allowSessionRefreshAfterFailure, response.statusCode == 401 {
+                    self.refreshSessionAndPerformRequest(request, completion: completion)
+                } else {
+                    completion(self.processStatusCode(response: response, data: data))
+                }
             } else {
                 completion(.failure(.responseUnexpected(response, data)))
             }
         }
         task.resume()
+    }
+
+    private func refreshSessionAndPerformRequest(_ request: URLRequest?, completion: @escaping (HTTPResult) -> Void) {
+        refreshSession() { error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            guard let session = self.session else {
+                completion(.failure(.sessionMissing))
+                return
+            }
+
+            var request = request
+            request?.setValue(session.authenticationToken, forHTTPHeaderField: HTTPHeaderField.tidepoolSessionToken.rawValue)
+            self.performRequest(request, allowSessionRefreshAfterFailure: false, completion: completion)
+        }
     }
 
     private func processStatusCode(response: HTTPURLResponse, data: Data?) -> HTTPResult {
@@ -416,6 +547,8 @@ public class TAPI {
     }
 
     private var urlSessionLocked: Locked<URLSession?>
+
+    private var sessionLocked: Locked<TSession?>
 
     private static var defaultEnvironments: [TEnvironment] {
         return DNSSRVRecordsImplicit.environments

--- a/TidepoolKit/TAPI.swift
+++ b/TidepoolKit/TAPI.swift
@@ -527,7 +527,6 @@ public class TAPI {
 
     private static var defaultURLSessionConfiguration: URLSessionConfiguration {
         let urlSessionConfiguration = URLSessionConfiguration.ephemeral
-        urlSessionConfiguration.waitsForConnectivity = true
         if urlSessionConfiguration.httpAdditionalHeaders == nil {
             urlSessionConfiguration.httpAdditionalHeaders = [:]
         }

--- a/TidepoolKit/TError.swift
+++ b/TidepoolKit/TError.swift
@@ -14,6 +14,9 @@ public enum TError: Error {
     /// A general network error not covered by another more specific error. May include a more detailed OS-level error.
     case network(Error?)
 
+    /// The session is missing.
+    case sessionMissing
+
     /// The request was invalid and not sent.
     case requestInvalid
 
@@ -79,6 +82,8 @@ extension TError: LocalizedError {
         switch self {
         case .network:
             return NSLocalizedString("A network error occurred.", comment: "The default localized description of the network error")
+        case .sessionMissing:
+            return NSLocalizedString("The session is missing.", comment: "The default localized description of the session missing error")
         case .requestInvalid:
             return NSLocalizedString("The request was invalid.", comment: "The default localized description of the request invalid error")
         case .requestMalformed:

--- a/TidepoolKit/TSession.swift
+++ b/TidepoolKit/TSession.swift
@@ -22,12 +22,26 @@ public struct TSession: Codable, Equatable {
 
     // The value of the optional X-Tidepool-Trace-Session header added to any future API network requests. The default UUID string
     // is usually sufficient, but can be changed or removed.
-    public var trace: String?
+    public let trace: String?
+
+    // The date the session was created
+    public let createdDate: Date
     
-    public init(environment: TEnvironment, authenticationToken: String, userId: String, trace: String? = UUID().uuidString) {
+    public init(environment: TEnvironment, authenticationToken: String, userId: String, trace: String? = UUID().uuidString, createdDate: Date = Date()) {
         self.environment = environment
         self.authenticationToken = authenticationToken
         self.userId = userId
         self.trace = trace
+        self.createdDate = createdDate
+    }
+
+    public var wantsRefresh: Bool { createdDate.addingTimeInterval(Self.refreshInterval) < Date() }
+
+    public static let refreshInterval: TimeInterval = .minutes(5)
+}
+
+extension TSession {
+    public init(session: TSession, authenticationToken: String) {
+        self.init(environment: session.environment, authenticationToken: authenticationToken, userId: session.userId, trace: session.trace)
     }
 }

--- a/TidepoolKitTests/Model/Prescription/TPrescriptionClaimTests.swift
+++ b/TidepoolKitTests/Model/Prescription/TPrescriptionClaimTests.swift
@@ -1,0 +1,28 @@
+//
+//  TPrescriptionClaimTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 4/30/21.
+//  Copyright © 2021 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TPrescriptionClaimTests: XCTestCase {
+    static let prescriptionClaim = TPrescriptionClaim(accessCode: "ABCDEF", birthday: "2004-01-04")
+    static let prescriptionClaimJSONDictionary: [String: Any] = [
+        "accessCode": "ABCDEF",
+        "birthday": "2004-01-04"
+    ]
+    
+    func testInitializer() {
+        let prescriptionClaim = TPrescriptionClaimTests.prescriptionClaim
+        XCTAssertEqual(prescriptionClaim.accessCode, "ABCDEF")
+        XCTAssertEqual(prescriptionClaim.birthday, "2004-01-04")
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TPrescriptionClaimTests.prescriptionClaim, TPrescriptionClaimTests.prescriptionClaimJSONDictionary)
+    }
+}

--- a/TidepoolKitTests/Model/Prescription/TPrescriptionTests.swift
+++ b/TidepoolKitTests/Model/Prescription/TPrescriptionTests.swift
@@ -1,0 +1,302 @@
+//
+//  TPrescriptionTests.swift
+//  TidepoolKitTests
+//
+//  Created by Darin Krauss on 4/30/21.
+//  Copyright © 2021 Tidepool Project. All rights reserved.
+//
+
+import XCTest
+import TidepoolKit
+
+class TPrescriptionTests: XCTestCase {
+    static let prescription = TPrescription(
+        id: "1234567890",
+        patientUserId: "a1b2c3d4e5",
+        accessCode: "ABCDEF",
+        state: .claimed,
+        latestRevision: TPrescriptionRevisionTests.revision,
+        expirationTime: Date.test,
+        prescriberUserId: "b2c3d4e5f6",
+        createdTime: Date.test,
+        createdUserId: "c3d4e5f6g7",
+        modifiedTime: Date.test,
+        modifiedUserId: "d4e5f6g7h8")
+    static let prescriptionJSONDictionary: [String: Any] = [
+        "id": "1234567890",
+        "patientUserId": "a1b2c3d4e5",
+        "accessCode": "ABCDEF",
+        "state": TPrescription.State.claimed.rawValue,
+        "latestRevision": TPrescriptionRevisionTests.revisionJSONDictionary,
+        "expirationTime": Date.testJSONString,
+        "prescriberUserId": "b2c3d4e5f6",
+        "createdTime": Date.testJSONString,
+        "createdUserId": "c3d4e5f6g7",
+        "modifiedTime": Date.testJSONString,
+        "modifiedUserId": "d4e5f6g7h8"
+    ]
+    
+    func testInitializer() {
+        let prescription = TPrescriptionTests.prescription
+        XCTAssertEqual(prescription.id, "1234567890")
+        XCTAssertEqual(prescription.patientUserId, "a1b2c3d4e5")
+        XCTAssertEqual(prescription.accessCode, "ABCDEF")
+        XCTAssertEqual(prescription.state, .claimed)
+        XCTAssertEqual(prescription.latestRevision, TPrescriptionRevisionTests.revision)
+        XCTAssertEqual(prescription.expirationTime, Date.test)
+        XCTAssertEqual(prescription.prescriberUserId, "b2c3d4e5f6")
+        XCTAssertEqual(prescription.createdTime, Date.test)
+        XCTAssertEqual(prescription.createdUserId, "c3d4e5f6g7")
+        XCTAssertEqual(prescription.modifiedTime, Date.test)
+        XCTAssertEqual(prescription.modifiedUserId, "d4e5f6g7h8")
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TPrescriptionTests.prescription, TPrescriptionTests.prescriptionJSONDictionary)
+    }
+}
+
+class TPrescriptionStateTests: XCTestCase {
+    func testState() {
+        XCTAssertEqual(TPrescription.State.draft.rawValue, "draft")
+        XCTAssertEqual(TPrescription.State.pending.rawValue, "pending")
+        XCTAssertEqual(TPrescription.State.submitted.rawValue, "submitted")
+        XCTAssertEqual(TPrescription.State.claimed.rawValue, "claimed")
+        XCTAssertEqual(TPrescription.State.expired.rawValue, "expired")
+        XCTAssertEqual(TPrescription.State.active.rawValue, "active")
+        XCTAssertEqual(TPrescription.State.inactive.rawValue, "inactive")
+    }
+}
+
+class TPrescriptionRevisionTests: XCTestCase {
+    static let revision = TPrescription.Revision(revisionId: 123, attributes: TPrescriptionAttributesTests.attributes)
+    static let revisionJSONDictionary: [String: Any] = [
+        "revisionId": 123,
+        "attributes": TPrescriptionAttributesTests.attributesJSONDictionary
+    ]
+    
+    func testInitializer() {
+        let revision = TPrescriptionRevisionTests.revision
+        XCTAssertEqual(revision.revisionId, 123)
+        XCTAssertEqual(revision.attributes, TPrescriptionAttributesTests.attributes)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TPrescriptionRevisionTests.revision, TPrescriptionRevisionTests.revisionJSONDictionary)
+    }
+}
+
+class TPrescriptionAttributesTests: XCTestCase {
+    static let attributes = TPrescription.Attributes(
+        accountType: .caregiver,
+        caregiverFirstName: "Parent",
+        caregiverLastName: "Doe",
+        firstName: "Child",
+        lastName: "Doe",
+        birthday: "2004-01-04",
+        mrn: "1234567890",
+        email: "parent.doe@email.com",
+        sex: .undisclosed,
+        weight: TPrescriptionWeightTests.weight,
+        yearOfDiagnosis: 2020,
+        phoneNumber: TPrescriptionPhoneNumberTests.phoneNumber,
+        initialSettings: TPrescriptionInitialSettingsTests.initialSettings,
+        training: .inModule,
+        therapySettings: .initial,
+        prescriberTermsAccepted: true,
+        state: .submitted,
+        createdTime: Date.test,
+        createdUserId: "abcdefghijklmnopqrstuvwxyz")
+    static let attributesJSONDictionary: [String: Any] = [
+        "accountType": TPrescription.AccountType.caregiver.rawValue,
+        "caregiverFirstName": "Parent",
+        "caregiverLastName": "Doe",
+        "firstName": "Child",
+        "lastName": "Doe",
+        "birthday": "2004-01-04",
+        "mrn": "1234567890",
+        "email": "parent.doe@email.com",
+        "sex": TPrescription.Sex.undisclosed.rawValue,
+        "weight": TPrescriptionWeightTests.weightJSONDictionary,
+        "yearOfDiagnosis": 2020,
+        "phoneNumber": TPrescriptionPhoneNumberTests.phoneNumberJSONDictionary,
+        "initialSettings": TPrescriptionInitialSettingsTests.initialSettingsJSONDictionary,
+        "training": TPrescription.Training.inModule.rawValue,
+        "therapySettings": TPrescription.TherapySettings.initial.rawValue,
+        "prescriberTermsAccepted": true,
+        "state": TPrescription.Attributes.State.submitted.rawValue,
+        "createdTime": Date.testJSONString,
+        "createdUserId": "abcdefghijklmnopqrstuvwxyz"
+    ]
+    
+    func testInitializer() {
+        let attributes = TPrescriptionAttributesTests.attributes
+        XCTAssertEqual(attributes.accountType, .caregiver)
+        XCTAssertEqual(attributes.caregiverFirstName, "Parent")
+        XCTAssertEqual(attributes.caregiverLastName, "Doe")
+        XCTAssertEqual(attributes.firstName, "Child")
+        XCTAssertEqual(attributes.lastName, "Doe")
+        XCTAssertEqual(attributes.birthday, "2004-01-04")
+        XCTAssertEqual(attributes.mrn, "1234567890")
+        XCTAssertEqual(attributes.email, "parent.doe@email.com")
+        XCTAssertEqual(attributes.sex, .undisclosed)
+        XCTAssertEqual(attributes.weight, TPrescriptionWeightTests.weight)
+        XCTAssertEqual(attributes.yearOfDiagnosis, 2020)
+        XCTAssertEqual(attributes.phoneNumber, TPrescriptionPhoneNumberTests.phoneNumber)
+        XCTAssertEqual(attributes.initialSettings, TPrescriptionInitialSettingsTests.initialSettings)
+        XCTAssertEqual(attributes.training, .inModule)
+        XCTAssertEqual(attributes.therapySettings, .initial)
+        XCTAssertEqual(attributes.prescriberTermsAccepted, true)
+        XCTAssertEqual(attributes.state, .submitted)
+        XCTAssertEqual(attributes.createdTime, Date.test)
+        XCTAssertEqual(attributes.createdUserId, "abcdefghijklmnopqrstuvwxyz")
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TPrescriptionAttributesTests.attributes, TPrescriptionAttributesTests.attributesJSONDictionary)
+    }
+}
+
+class TPrescriptionAttributesStateTests: XCTestCase {
+    func testState() {
+        XCTAssertEqual(TPrescription.Attributes.State.draft.rawValue, "draft")
+        XCTAssertEqual(TPrescription.Attributes.State.pending.rawValue, "pending")
+        XCTAssertEqual(TPrescription.Attributes.State.submitted.rawValue, "submitted")
+    }
+}
+
+class TPrescriptionAccountTypeTests: XCTestCase {
+    func testAccountType() {
+        XCTAssertEqual(TPrescription.AccountType.patient.rawValue, "patient")
+        XCTAssertEqual(TPrescription.AccountType.caregiver.rawValue, "caregiver")
+    }
+}
+
+class TPrescriptionSexTests: XCTestCase {
+    func testSex() {
+        XCTAssertEqual(TPrescription.Sex.male.rawValue, "male")
+        XCTAssertEqual(TPrescription.Sex.female.rawValue, "female")
+        XCTAssertEqual(TPrescription.Sex.undisclosed.rawValue, "undisclosed")
+    }
+}
+
+class TPrescriptionWeightTests: XCTestCase {
+    static let weight = TPrescription.Weight(value: 123, units: .kg)
+    static let weightJSONDictionary: [String: Any] = [
+        "value": 123,
+        "units": "kg"
+    ]
+    
+    func testInitializer() {
+        let weight = TPrescriptionWeightTests.weight
+        XCTAssertEqual(weight.value, 123)
+        XCTAssertEqual(weight.units, .kg)
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TPrescriptionWeightTests.weight, TPrescriptionWeightTests.weightJSONDictionary)
+    }
+}
+
+class TPrescriptionWeightUnitsTests: XCTestCase {
+    func testUnits() {
+        XCTAssertEqual(TPrescription.Weight.Units.kg.rawValue, "kg")
+    }
+}
+
+class TPrescriptionPhoneNumberTests: XCTestCase {
+    static let phoneNumber = TPrescription.PhoneNumber(countryCode: 123, number: "(234) 345-4566")
+    static let phoneNumberJSONDictionary: [String: Any] = [
+        "countryCode": 123,
+        "number": "(234) 345-4566"
+    ]
+    
+    func testInitializer() {
+        let phoneNumber = TPrescriptionPhoneNumberTests.phoneNumber
+        XCTAssertEqual(phoneNumber.countryCode, 123)
+        XCTAssertEqual(phoneNumber.number, "(234) 345-4566")
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TPrescriptionPhoneNumberTests.phoneNumber, TPrescriptionPhoneNumberTests.phoneNumberJSONDictionary)
+    }
+}
+
+class TPrescriptionInitialSettingsTests: XCTestCase {
+    static let initialSettings = TPrescription.InitialSettings(
+        bloodGlucoseUnits: .milligramsPerDeciliter,
+        basalRateSchedule: [TPumpSettingsDatumBasalRateStartTests.basalRateStart,
+                            TPumpSettingsDatumBasalRateStartTests.basalRateStart],
+        bloodGlucoseTargetPhysicalActivity: TBloodGlucoseTargetTests.target,
+        bloodGlucoseTargetPreprandial: TBloodGlucoseTargetTests.target,
+        bloodGlucoseTargetSchedule: [TBloodGlucoseStartTargetTests.startTarget,
+                                     TBloodGlucoseStartTargetTests.startTarget],
+        carbohydrateRatioSchedule: [TPumpSettingsDatumCarbohydrateRatioStartTests.carbohydrateRatioStart,
+                                    TPumpSettingsDatumCarbohydrateRatioStartTests.carbohydrateRatioStart],
+        glucoseSafetyLimit: 78.9,
+        insulinModel: .rapidChild,
+        insulinSensitivitySchedule: [TPumpSettingsDatumInsulinSensitivityStartTests.insulinSensitivityStart,
+                                     TPumpSettingsDatumInsulinSensitivityStartTests.insulinSensitivityStart],
+        basalRateMaximum: TPumpSettingsDatumBasalRateMaximumTests.rateMaximum,
+        bolusAmountMaximum: TPumpSettingsDatumBolusAmountMaximumTests.amountMaximum,
+        pumpId: "ABCDEFGHIJ",
+        cgmId: "1234567890")
+    static let initialSettingsJSONDictionary: [String: Any] = [
+        "bloodGlucoseUnits": TBloodGlucose.Units.milligramsPerDeciliter.rawValue,
+        "basalRateSchedule": [TPumpSettingsDatumBasalRateStartTests.basalRateStartJSONDictionary,
+                              TPumpSettingsDatumBasalRateStartTests.basalRateStartJSONDictionary],
+        "bloodGlucoseTargetPhysicalActivity": TBloodGlucoseTargetTests.targetJSONDictionary,
+        "bloodGlucoseTargetPreprandial": TBloodGlucoseTargetTests.targetJSONDictionary,
+        "bloodGlucoseTargetSchedule": [TBloodGlucoseStartTargetTests.startTargetJSONDictionary,
+                                       TBloodGlucoseStartTargetTests.startTargetJSONDictionary],
+        "carbohydrateRatioSchedule": [TPumpSettingsDatumCarbohydrateRatioStartTests.carbohydrateRatioStartJSONDictionary,
+                                      TPumpSettingsDatumCarbohydrateRatioStartTests.carbohydrateRatioStartJSONDictionary],
+        "glucoseSafetyLimit": 78.9,
+        "insulinModel": TPumpSettingsDatum.InsulinModel.ModelType.rapidChild.rawValue,
+        "insulinSensitivitySchedule": [TPumpSettingsDatumInsulinSensitivityStartTests.insulinSensitivityStartJSONDictionary,
+                                       TPumpSettingsDatumInsulinSensitivityStartTests.insulinSensitivityStartJSONDictionary],
+        "basalRateMaximum": TPumpSettingsDatumBasalRateMaximumTests.rateMaximumJSONDictionary,
+        "bolusAmountMaximum": TPumpSettingsDatumBolusAmountMaximumTests.amountMaximumJSONDictionary,
+        "pumpId": "ABCDEFGHIJ",
+        "cgmId": "1234567890"
+    ]
+    
+    func testInitializer() {
+        let initialSettings = TPrescriptionInitialSettingsTests.initialSettings
+        XCTAssertEqual(initialSettings.bloodGlucoseUnits, .milligramsPerDeciliter)
+        XCTAssertEqual(initialSettings.basalRateSchedule, [TPumpSettingsDatumBasalRateStartTests.basalRateStart,
+                                                           TPumpSettingsDatumBasalRateStartTests.basalRateStart])
+        XCTAssertEqual(initialSettings.bloodGlucoseTargetPhysicalActivity, TBloodGlucoseTargetTests.target)
+        XCTAssertEqual(initialSettings.bloodGlucoseTargetPreprandial, TBloodGlucoseTargetTests.target)
+        XCTAssertEqual(initialSettings.bloodGlucoseTargetSchedule, [TBloodGlucoseStartTargetTests.startTarget,
+                                                                    TBloodGlucoseStartTargetTests.startTarget])
+        XCTAssertEqual(initialSettings.carbohydrateRatioSchedule, [TPumpSettingsDatumCarbohydrateRatioStartTests.carbohydrateRatioStart,
+                                                                   TPumpSettingsDatumCarbohydrateRatioStartTests.carbohydrateRatioStart])
+        XCTAssertEqual(initialSettings.glucoseSafetyLimit, 78.9)
+        XCTAssertEqual(initialSettings.insulinModel, .rapidChild)
+        XCTAssertEqual(initialSettings.insulinSensitivitySchedule, [TPumpSettingsDatumInsulinSensitivityStartTests.insulinSensitivityStart,
+                                                                    TPumpSettingsDatumInsulinSensitivityStartTests.insulinSensitivityStart])
+        XCTAssertEqual(initialSettings.basalRateMaximum, TPumpSettingsDatumBasalRateMaximumTests.rateMaximum)
+        XCTAssertEqual(initialSettings.bolusAmountMaximum, TPumpSettingsDatumBolusAmountMaximumTests.amountMaximum)
+        XCTAssertEqual(initialSettings.pumpId, "ABCDEFGHIJ")
+        XCTAssertEqual(initialSettings.cgmId, "1234567890")
+    }
+    
+    func testCodableAsJSON() {
+        XCTAssertCodableAsJSON(TPrescriptionInitialSettingsTests.initialSettings, TPrescriptionInitialSettingsTests.initialSettingsJSONDictionary)
+    }
+}
+
+class TPrescriptionTrainingTests: XCTestCase {
+    func testTraining() {
+        XCTAssertEqual(TPrescription.Training.inPerson.rawValue, "inPerson")
+        XCTAssertEqual(TPrescription.Training.inModule.rawValue, "inModule")
+    }
+}
+
+class TPrescriptionTherapySettingsTests: XCTestCase {
+    func testTherapySettings() {
+        XCTAssertEqual(TPrescription.TherapySettings.initial.rawValue, "initial")
+        XCTAssertEqual(TPrescription.TherapySettings.transferPumpSettings.rawValue, "transferPumpSettings")
+    }
+}

--- a/TidepoolKitTests/TAPITests.swift
+++ b/TidepoolKitTests/TAPITests.swift
@@ -18,14 +18,40 @@ class TAPITests: XCTestCase {
     override func setUp() {
         super.setUp()
 
+        URLProtocolMock.handlers = []
+
         self.api = TAPI(automaticallyFetchEnvironments: false)
         self.api.urlSessionConfiguration.protocolClasses = [URLProtocolMock.self]
         self.environment = TEnvironment(host: "test.org", port: 443)
     }
 
+    override func tearDown() {
+        XCTAssertTrue(URLProtocolMock.handlers.isEmpty)
+    }
+
     static var randomString: String { UUID().uuidString }
 
     struct TestError: Error {}
+
+    func setUpNetworkError() {
+        URLProtocolMock.handlers[0].error = TestError()
+    }
+
+    func setUpRequestNotAuthenticated() {
+        URLProtocolMock.handlers[0].success?.statusCode = 401
+    }
+
+    func setUpRequestNotAuthorized() {
+        URLProtocolMock.handlers[0].success?.statusCode = 403
+    }
+
+    func setUpResponseNotAuthenticated() {
+        URLProtocolMock.handlers[0].success?.headers = nil
+    }
+
+    func setUpResponseMalformedJSON() {
+        URLProtocolMock.handlers[0].success?.body = nil
+    }
 }
 
 class TAPIEnvironmentTests: TAPITests {
@@ -51,161 +77,16 @@ class TAPILoginTests: TAPITests {
     override func setUp() {
         super.setUp()
 
-        URLProtocolMock.validator = URLProtocolMock.Validator(url: "https://test.org/auth/login",
-                                                              method: "POST",
-                                                              headers: ["Authorization": "Basic \(Data("\(email):\(password)".utf8).base64EncodedString())"])
-        URLProtocolMock.error = nil
-        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 201,
-                                                          headers: ["X-Tidepool-Session-Token": authenticationToken],
-                                                          body: LoginResponse(userId: userId, email: email, emailVerified: true, termsAccepted: "2010-01-01T12:34:56Z"))
+        URLProtocolMock.handlers = [URLProtocolMock.Handler(validator: URLProtocolMock.Validator(url: "https://test.org/auth/login",
+                                                                                                 method: "POST",
+                                                                                                 headers: ["Authorization": "Basic \(Data("\(email):\(password)".utf8).base64EncodedString())"]),
+                                                            success: URLProtocolMock.Success(statusCode: 201,
+                                                                                             headers: ["X-Tidepool-Session-Token": authenticationToken],
+                                                                                             body: LoginResponse(userId: userId, email: email, emailVerified: true, termsAccepted: "2010-01-01T12:34:56Z")))]
     }
 
     func testNetworkError() {
-        URLProtocolMock.error = TestError()
-        guard case .failure(let error) = performRequest(), case .network(let networkError) = error else {
-            XCTFail()
-            return
-        }
-        XCTAssertNotNil(networkError)
-    }
-
-    func testRequestNotAuthenticated() {
-        URLProtocolMock.success?.statusCode = 401
-        guard case .failure(let error) = performRequest(), case .requestNotAuthenticated = error else {
-            XCTFail()
-            return
-        }
-    }
-
-    func testRequestEmailNotVerified() {
-        URLProtocolMock.success?.statusCode = 403
-        guard case .failure(let error) = performRequest(), case .requestEmailNotVerified = error else {
-            XCTFail()
-            return
-        }
-    }
-
-    func testResponseNotAuthenticated() {
-        URLProtocolMock.success?.headers = nil
-        guard case .failure(let error) = performRequest(), case .responseNotAuthenticated = error else {
-            XCTFail()
-            return
-        }
-    }
-
-    func testResponseMalformedJSON() {
-        URLProtocolMock.success?.body = nil
-        guard case .failure(let error) = performRequest(), case .responseMalformedJSON = error else {
-            XCTFail()
-            return
-        }
-    }
-
-    func testTermsOfUseNotAccepted() {
-        URLProtocolMock.success?.set(body: LoginResponse(userId: userId, email: email, emailVerified: true))
-        guard case .failure(let error) = performRequest(), case .requestTermsOfServiceNotAccepted = error else {
-            XCTFail()
-            return
-        }
-    }
-
-    func testSuccess() {
-        guard case .success(let session) = performRequest() else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(session.environment, self.environment)
-        XCTAssertEqual(session.authenticationToken, authenticationToken)
-        XCTAssertEqual(session.userId, userId)
-        XCTAssertNotNil(session.trace)
-    }
-
-    private func performRequest() -> Result<TSession, TError>? {
-        let expectation = XCTestExpectationWithResult<TSession, TError>()
-        api.login(environment: environment, email: email, password: password) { expectation.fulfill($0) }
-        XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
-        return expectation.result
-    }
-}
-
-class TAPISessionTests: TAPITests {
-    var session: TSession!
-    var headers: [String: String]!
-
-    override func setUp() {
-        super.setUp()
-
-        session = TSession(environment: environment, authenticationToken: authenticationToken, userId: userId)
-        headers = ["X-Tidepool-Session-Token": authenticationToken, "X-Tidepool-Trace-Session": session.trace!]
-    }
-}
-
-class TAPIRefreshTests: TAPISessionTests {
-    let refreshedAuthenticationToken = randomString
-
-    override func setUp() {
-        super.setUp()
-
-        URLProtocolMock.validator = URLProtocolMock.Validator(url: "https://test.org/auth/login", method: "GET", headers: headers)
-        URLProtocolMock.error = nil
-        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200, headers: ["X-Tidepool-Session-Token": refreshedAuthenticationToken])
-    }
-
-    func testNetworkError() {
-        URLProtocolMock.error = TestError()
-        guard case .failure(let error) = performRequest(), case .network(let networkError) = error else {
-            XCTFail()
-            return
-        }
-        XCTAssertNotNil(networkError)
-    }
-
-    func testRequestNotAuthenticated() {
-        URLProtocolMock.success?.statusCode = 401
-        guard case .failure(let error) = performRequest(), case .requestNotAuthenticated = error else {
-            XCTFail()
-            return
-        }
-    }
-
-    func testResponseNotAuthenticated() {
-        URLProtocolMock.success?.headers = nil
-        guard case .failure(let error) = performRequest(), case .responseNotAuthenticated = error else {
-            XCTFail()
-            return
-        }
-    }
-
-    func testSuccess() {
-        guard case .success(let refreshedSession) = performRequest() else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(refreshedSession.environment, session.environment)
-        XCTAssertNotEqual(refreshedSession.authenticationToken, session.authenticationToken)
-        XCTAssertEqual(refreshedSession.userId, session.userId)
-        XCTAssertEqual(refreshedSession.trace, session.trace)
-    }
-
-    private func performRequest() -> Result<TSession, TError>? {
-        let expectation = XCTestExpectationWithResult<TSession, TError>()
-        api.refresh(session: session) { expectation.fulfill($0) }
-        XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
-        return expectation.result
-    }
-}
-
-class TAPILogoutTests: TAPISessionTests {
-    override func setUp() {
-        super.setUp()
-
-        URLProtocolMock.validator = URLProtocolMock.Validator(url: "https://test.org/auth/logout", method: "POST", headers: headers)
-        URLProtocolMock.error = nil
-        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200)
-    }
-
-    func testNetworkError() {
-        URLProtocolMock.error = TestError()
+        setUpNetworkError()
         guard let error = performRequest(), case .network(let networkError) = error else {
             XCTFail()
             return
@@ -214,7 +95,152 @@ class TAPILogoutTests: TAPISessionTests {
     }
 
     func testRequestNotAuthenticated() {
-        URLProtocolMock.success?.statusCode = 401
+        setUpRequestNotAuthenticated()
+        guard let error = performRequest(), case .requestNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testRequestEmailNotVerified() {
+        setUpRequestNotAuthorized()
+        guard let error = performRequest(), case .requestEmailNotVerified = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testResponseNotAuthenticated() {
+        setUpResponseNotAuthenticated()
+        guard let error = performRequest(), case .responseNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testResponseMalformedJSON() {
+        setUpResponseMalformedJSON()
+        guard let error = performRequest(), case .responseMalformedJSON = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testTermsOfUseNotAccepted() {
+        URLProtocolMock.handlers[0].success?.set(body: LoginResponse(userId: userId, email: email, emailVerified: true))
+        guard let error = performRequest(), case .requestTermsOfServiceNotAccepted = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testSuccess() {
+        guard performRequest() == nil else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(api.session?.environment, environment)
+        XCTAssertEqual(api.session?.authenticationToken, authenticationToken)
+        XCTAssertEqual(api.session?.userId, userId)
+        XCTAssertNotNil(api.session?.trace)
+    }
+
+    private func performRequest() -> TError? {
+        let expectation = XCTestExpectationWithError()
+        api.login(environment: environment, email: email, password: password) { expectation.fulfill($0) }
+        XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
+        return expectation.error
+    }
+}
+
+class TAPISessionTests: TAPITests {
+    var session: TSession!
+    var headers: [String: String]!
+    var refreshAuthenticationToken = randomString
+    var refreshHandler: URLProtocolMock.Handler!
+
+    override func setUp() {
+        super.setUp()
+
+        session = TSession(environment: environment, authenticationToken: authenticationToken, userId: userId)
+        headers = ["X-Tidepool-Session-Token": authenticationToken, "X-Tidepool-Trace-Session": session.trace!]
+        refreshHandler = URLProtocolMock.Handler(validator: URLProtocolMock.Validator(url: "https://test.org/auth/login", method: "GET", headers: headers),
+                                                 success: URLProtocolMock.Success(statusCode: 200, headers: ["X-Tidepool-Session-Token": refreshAuthenticationToken]))
+
+        api.session = session
+    }
+}
+
+class TAPIRefreshTests: TAPISessionTests {
+    override func setUp() {
+        super.setUp()
+
+        URLProtocolMock.handlers = [refreshHandler]
+    }
+
+    func testNetworkError() {
+        setUpNetworkError()
+        guard let error = performRequest(), case .network(let networkError) = error else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(networkError)
+    }
+
+    func testRequestNotAuthenticated() {
+        setUpRequestNotAuthenticated()
+        guard let error = performRequest(), case .requestNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testResponseNotAuthenticated() {
+        setUpResponseNotAuthenticated()
+        guard let error = performRequest(), case .responseNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testSuccess() {
+        guard performRequest() == nil else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(api.session?.environment, session.environment)
+        XCTAssertEqual(api.session?.authenticationToken, refreshAuthenticationToken)
+        XCTAssertEqual(api.session?.userId, session.userId)
+        XCTAssertEqual(api.session?.trace, session.trace)
+    }
+
+    private func performRequest() -> TError? {
+        let expectation = XCTestExpectationWithError()
+        api.refreshSession() { expectation.fulfill($0) }
+        XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
+        return expectation.error
+    }
+}
+
+class TAPILogoutTests: TAPISessionTests {
+    override func setUp() {
+        super.setUp()
+
+        URLProtocolMock.handlers = [URLProtocolMock.Handler(validator: URLProtocolMock.Validator(url: "https://test.org/auth/logout", method: "POST", headers: headers),
+                                                            success: URLProtocolMock.Success(statusCode: 200))]
+    }
+
+    func testNetworkError() {
+        setUpNetworkError()
+        guard let error = performRequest(), case .network(let networkError) = error else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(networkError)
+    }
+
+    func testRequestNotAuthenticated() {
+        setUpRequestNotAuthenticated()
         guard let error = performRequest(), case .requestNotAuthenticated = error else {
             XCTFail()
             return
@@ -226,27 +252,43 @@ class TAPILogoutTests: TAPISessionTests {
             XCTFail()
             return
         }
+        XCTAssertNil(api.session)
     }
 
     private func performRequest() -> TError? {
         let expectation = XCTestExpectationWithError()
-        api.logout(session: session) { expectation.fulfill($0) }
+        api.logout() { expectation.fulfill($0) }
         XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
         return expectation.error
     }
 }
 
-class TAPIGetProfileTests: TAPISessionTests {
+class TAPIRefreshSessionTests: TAPISessionTests {
+    override func setUpRequestNotAuthenticated() {
+        super.setUpRequestNotAuthenticated()
+        URLProtocolMock.handlers.append(refreshHandler)
+        URLProtocolMock.handlers.append(URLProtocolMock.handlers[0])
+        URLProtocolMock.handlers[2].validator.headers = ["X-Tidepool-Session-Token": refreshAuthenticationToken, "X-Tidepool-Trace-Session": session.trace!]
+    }
+
+    func setUpSessionWantsRefresh() {
+        api.session = TSession(session: session, createdDate: Date().addingTimeInterval(-TSession.refreshInterval).addingTimeInterval(.seconds(-1)))
+
+        URLProtocolMock.handlers.insert(refreshHandler, at: 0)
+        URLProtocolMock.handlers[1].validator.headers = ["X-Tidepool-Session-Token": refreshAuthenticationToken, "X-Tidepool-Trace-Session": session.trace!]
+    }
+}
+
+class TAPIGetProfileTests: TAPIRefreshSessionTests {
     override func setUp() {
         super.setUp()
 
-        URLProtocolMock.validator = URLProtocolMock.Validator(url: "https://test.org/metadata/\(userId)/profile", method: "GET", headers: headers)
-        URLProtocolMock.error = nil
-        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200, headers: headers, body: TProfileTests.profile)
+        URLProtocolMock.handlers = [URLProtocolMock.Handler(validator: URLProtocolMock.Validator(url: "https://test.org/metadata/\(userId)/profile", method: "GET", headers: headers),
+                                                            success: URLProtocolMock.Success(statusCode: 200, headers: headers, body: TProfileTests.profile))]
     }
 
     func testNetworkError() {
-        URLProtocolMock.error = TestError()
+        setUpNetworkError()
         guard case .failure(let error) = performRequest(), case .network(let networkError) = error else {
             XCTFail()
             return
@@ -255,7 +297,7 @@ class TAPIGetProfileTests: TAPISessionTests {
     }
 
     func testRequestNotAuthenticated() {
-        URLProtocolMock.success?.statusCode = 401
+        setUpRequestNotAuthenticated()
         guard case .failure(let error) = performRequest(), case .requestNotAuthenticated = error else {
             XCTFail()
             return
@@ -263,7 +305,7 @@ class TAPIGetProfileTests: TAPISessionTests {
     }
 
     func testRequestNotAuthorized() {
-        URLProtocolMock.success?.statusCode = 403
+        setUpRequestNotAuthorized()
         guard case .failure(let error) = performRequest(), case .requestNotAuthorized = error else {
             XCTFail()
             return
@@ -271,7 +313,7 @@ class TAPIGetProfileTests: TAPISessionTests {
     }
 
     func testResponseMalformedJSON() {
-        URLProtocolMock.success?.body = nil
+        setUpResponseMalformedJSON()
         guard case .failure(let error) = performRequest(), case .responseMalformedJSON = error else {
             XCTFail()
             return
@@ -286,26 +328,32 @@ class TAPIGetProfileTests: TAPISessionTests {
         XCTAssertEqual(profile, TProfileTests.profile)
     }
 
+    func testSuccessAfterRefresh() {
+        setUpSessionWantsRefresh()
+        testSuccess()
+    }
+
     private func performRequest() -> Result<TProfile, TError>? {
         let expectation = XCTestExpectationWithResult<TProfile, TError>()
-        api.getProfile(session: session) { expectation.fulfill($0) }
+        api.getProfile() { expectation.fulfill($0) }
         XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
         return expectation.result
     }
 }
 
-class TAPIListDataSetsTests: TAPISessionTests {
+class TAPIClaimPrescriptionTests: TAPIRefreshSessionTests {
+    var prescriptionClaim: TPrescriptionClaim!
+
     override func setUp() {
         super.setUp()
 
-        let url = "https://test.org/v1/users/\(userId)/data_sets?client.name=org.tidepool.Example&deleted=true&deviceId=ExampleDeviceId"
-        URLProtocolMock.validator = URLProtocolMock.Validator(url: url, method: "GET", headers: headers)
-        URLProtocolMock.error = nil
-        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200, headers: headers, body: [TDataSetTests.dataSet])
+        prescriptionClaim = TPrescriptionClaim(accessCode: "ABCDEF", birthday: "2004-01-04")
+        URLProtocolMock.handlers = [URLProtocolMock.Handler(validator: URLProtocolMock.Validator(url: "https://test.org/v1/prescriptions/claim", method: "POST", headers: headers, body: prescriptionClaim),
+                                                            success: URLProtocolMock.Success(statusCode: 201, headers: headers, body: TPrescriptionTests.prescription))]
     }
 
     func testNetworkError() {
-        URLProtocolMock.error = TestError()
+        setUpNetworkError()
         guard case .failure(let error) = performRequest(), case .network(let networkError) = error else {
             XCTFail()
             return
@@ -314,7 +362,7 @@ class TAPIListDataSetsTests: TAPISessionTests {
     }
 
     func testRequestNotAuthenticated() {
-        URLProtocolMock.success?.statusCode = 401
+        setUpRequestNotAuthenticated()
         guard case .failure(let error) = performRequest(), case .requestNotAuthenticated = error else {
             XCTFail()
             return
@@ -322,7 +370,7 @@ class TAPIListDataSetsTests: TAPISessionTests {
     }
 
     func testRequestNotAuthorized() {
-        URLProtocolMock.success?.statusCode = 403
+        setUpRequestNotAuthorized()
         guard case .failure(let error) = performRequest(), case .requestNotAuthorized = error else {
             XCTFail()
             return
@@ -330,7 +378,70 @@ class TAPIListDataSetsTests: TAPISessionTests {
     }
 
     func testResponseMalformedJSON() {
-        URLProtocolMock.success?.body = nil
+        setUpResponseMalformedJSON()
+        guard case .failure(let error) = performRequest(), case .responseMalformedJSON = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testSuccess() {
+        guard case .success(let claimedPrescription) = performRequest() else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(claimedPrescription, TPrescriptionTests.prescription)
+    }
+
+    func testSuccessAfterRefresh() {
+        setUpSessionWantsRefresh()
+        testSuccess()
+    }
+
+    private func performRequest() -> Result<TPrescription, TError>? {
+        let expectation = XCTestExpectationWithResult<TPrescription, TError>()
+        api.claimPrescription(prescriptionClaim: prescriptionClaim) { expectation.fulfill($0) }
+        XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
+        return expectation.result
+    }
+}
+
+class TAPIListDataSetsTests: TAPIRefreshSessionTests {
+    override func setUp() {
+        super.setUp()
+
+        let url = "https://test.org/v1/users/\(userId)/data_sets?client.name=org.tidepool.Example&deleted=true&deviceId=ExampleDeviceId"
+        URLProtocolMock.handlers = [URLProtocolMock.Handler(validator: URLProtocolMock.Validator(url: url, method: "GET", headers: headers),
+                                                            success: URLProtocolMock.Success(statusCode: 200, headers: headers, body: [TDataSetTests.dataSet]))]
+    }
+
+    func testNetworkError() {
+        setUpNetworkError()
+        guard case .failure(let error) = performRequest(), case .network(let networkError) = error else {
+            XCTFail()
+            return
+        }
+        XCTAssertNotNil(networkError)
+    }
+
+    func testRequestNotAuthenticated() {
+        setUpRequestNotAuthenticated()
+        guard case .failure(let error) = performRequest(), case .requestNotAuthenticated = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testRequestNotAuthorized() {
+        setUpRequestNotAuthorized()
+        guard case .failure(let error) = performRequest(), case .requestNotAuthorized = error else {
+            XCTFail()
+            return
+        }
+    }
+
+    func testResponseMalformedJSON() {
+        setUpResponseMalformedJSON()
         guard case .failure(let error) = performRequest(), case .responseMalformedJSON = error else {
             XCTFail()
             return
@@ -345,28 +456,32 @@ class TAPIListDataSetsTests: TAPISessionTests {
         XCTAssertEqual(dataSets, [TDataSetTests.dataSet])
     }
 
+    func testSuccessAfterRefresh() {
+        setUpSessionWantsRefresh()
+        testSuccess()
+    }
+
     private func performRequest() -> Result<[TDataSet], TError>? {
         let expectation = XCTestExpectationWithResult<[TDataSet], TError>()
-        api.listDataSets(filter: TDataSetFilterTests.filter, session: session) { expectation.fulfill($0) }
+        api.listDataSets(filter: TDataSetFilterTests.filter) { expectation.fulfill($0) }
         XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
         return expectation.result
     }
 }
 
-class TAPICreateDataSetTests: TAPISessionTests {
+class TAPICreateDataSetTests: TAPIRefreshSessionTests {
     var dataSet: TDataSet!
 
     override func setUp() {
         super.setUp()
 
         dataSet = TDataSet(dataSetType: .continuous, client: TDataSetClientTests.client, deduplicator: TDataSet.Deduplicator(name: .dataSetDeleteOrigin))
-        URLProtocolMock.validator = URLProtocolMock.Validator(url: "https://test.org/v1/users/\(userId)/data_sets", method: "POST", headers: headers, body: dataSet)
-        URLProtocolMock.error = nil
-        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200, headers: headers, body: LegacyResponse.Success(data: TDataSetTests.dataSet))
+        URLProtocolMock.handlers = [URLProtocolMock.Handler(validator: URLProtocolMock.Validator(url: "https://test.org/v1/users/\(userId)/data_sets", method: "POST", headers: headers, body: dataSet),
+                                                            success: URLProtocolMock.Success(statusCode: 200, headers: headers, body: LegacyResponse.Success(data: TDataSetTests.dataSet)))]
     }
 
     func testNetworkError() {
-        URLProtocolMock.error = TestError()
+        setUpNetworkError()
         guard case .failure(let error) = performRequest(), case .network(let networkError) = error else {
             XCTFail()
             return
@@ -375,7 +490,7 @@ class TAPICreateDataSetTests: TAPISessionTests {
     }
 
     func testRequestNotAuthenticated() {
-        URLProtocolMock.success?.statusCode = 401
+        setUpRequestNotAuthenticated()
         guard case .failure(let error) = performRequest(), case .requestNotAuthenticated = error else {
             XCTFail()
             return
@@ -383,7 +498,7 @@ class TAPICreateDataSetTests: TAPISessionTests {
     }
 
     func testRequestNotAuthorized() {
-        URLProtocolMock.success?.statusCode = 403
+        setUpRequestNotAuthorized()
         guard case .failure(let error) = performRequest(), case .requestNotAuthorized = error else {
             XCTFail()
             return
@@ -391,7 +506,7 @@ class TAPICreateDataSetTests: TAPISessionTests {
     }
 
     func testResponseMalformedJSON() {
-        URLProtocolMock.success?.body = nil
+        setUpResponseMalformedJSON()
         guard case .failure(let error) = performRequest(), case .responseMalformedJSON = error else {
             XCTFail()
             return
@@ -406,26 +521,30 @@ class TAPICreateDataSetTests: TAPISessionTests {
         XCTAssertEqual(createdDataSet, TDataSetTests.dataSet)
     }
 
+    func testSuccessAfterRefresh() {
+        setUpSessionWantsRefresh()
+        testSuccess()
+    }
+
     private func performRequest() -> Result<TDataSet, TError>? {
         let expectation = XCTestExpectationWithResult<TDataSet, TError>()
-        api.createDataSet(dataSet, session: session) { expectation.fulfill($0) }
+        api.createDataSet(dataSet) { expectation.fulfill($0) }
         XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
         return expectation.result
     }
 }
 
-class TAPIListDataTests: TAPISessionTests {
+class TAPIListDataTests: TAPIRefreshSessionTests {
     override func setUp() {
         super.setUp()
 
         let url = "https://test.org/data/\(userId)?startDate=\(Date.testJSONString)"
-        URLProtocolMock.validator = URLProtocolMock.Validator(url: url, method: "GET", headers: headers)
-        URLProtocolMock.error = nil
-        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200, headers: headers, body: [TCBGDatumTests.cbg, TFoodDatumTests.food])
+        URLProtocolMock.handlers = [URLProtocolMock.Handler(validator: URLProtocolMock.Validator(url: url, method: "GET", headers: headers),
+                                                            success: URLProtocolMock.Success(statusCode: 200, headers: headers, body: [TCBGDatumTests.cbg, TFoodDatumTests.food]))]
     }
 
     func testNetworkError() {
-        URLProtocolMock.error = TestError()
+        setUpNetworkError()
         guard case .failure(let error) = performRequest(), case .network(let networkError) = error else {
             XCTFail()
             return
@@ -434,7 +553,7 @@ class TAPIListDataTests: TAPISessionTests {
     }
 
     func testRequestNotAuthenticated() {
-        URLProtocolMock.success?.statusCode = 401
+        setUpRequestNotAuthenticated()
         guard case .failure(let error) = performRequest(), case .requestNotAuthenticated = error else {
             XCTFail()
             return
@@ -442,7 +561,7 @@ class TAPIListDataTests: TAPISessionTests {
     }
 
     func testRequestNotAuthorized() {
-        URLProtocolMock.success?.statusCode = 403
+        setUpRequestNotAuthorized()
         guard case .failure(let error) = performRequest(), case .requestNotAuthorized = error else {
             XCTFail()
             return
@@ -450,7 +569,7 @@ class TAPIListDataTests: TAPISessionTests {
     }
 
     func testResponseMalformedJSON() {
-        URLProtocolMock.success?.body = nil
+        setUpResponseMalformedJSON()
         guard case .failure(let error) = performRequest(), case .responseMalformedJSON = error else {
             XCTFail()
             return
@@ -466,28 +585,32 @@ class TAPIListDataTests: TAPISessionTests {
         XCTAssertEqual(malformed.count, 0)
     }
 
+    func testSuccessAfterRefresh() {
+        setUpSessionWantsRefresh()
+        testSuccess()
+    }
+
     private func performRequest() -> Result<([TDatum], [String: [String: Any]]), TError>? {
         let expectation = XCTestExpectationWithResult<([TDatum], [String: [String: Any]]), TError>()
-        api.listData(filter: TDatum.Filter(startDate: Date.test), session: session) { expectation.fulfill($0) }
+        api.listData(filter: TDatum.Filter(startDate: Date.test)) { expectation.fulfill($0) }
         XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
         return expectation.result
     }
 }
 
-class TAPICreateDataTests: TAPISessionTests {
+class TAPICreateDataTests: TAPIRefreshSessionTests {
     let dataSetId = randomString
     let data = [TCBGDatumTests.cbg, TFoodDatumTests.food]
 
     override func setUp() {
         super.setUp()
 
-        URLProtocolMock.validator = URLProtocolMock.Validator(url: "https://test.org/v1/data_sets/\(dataSetId)/data", method: "POST", headers: headers, body: data)
-        URLProtocolMock.error = nil
-        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200, headers: headers, body: LegacyResponse.Success<DataResponse>(data: DataResponse()))
+        URLProtocolMock.handlers = [URLProtocolMock.Handler(validator: URLProtocolMock.Validator(url: "https://test.org/v1/data_sets/\(dataSetId)/data", method: "POST", headers: headers, body: data),
+                                                            success: URLProtocolMock.Success(statusCode: 200, headers: headers, body: LegacyResponse.Success<DataResponse>(data: DataResponse())))]
     }
 
     func testNetworkError() {
-        URLProtocolMock.error = TestError()
+        setUpNetworkError()
         guard let error = performRequest(), case .network(let networkError) = error else {
             XCTFail()
             return
@@ -496,7 +619,7 @@ class TAPICreateDataTests: TAPISessionTests {
     }
 
     func testRequestNotAuthenticated() {
-        URLProtocolMock.success?.statusCode = 401
+        setUpRequestNotAuthenticated()
         guard let error = performRequest(), case .requestNotAuthenticated = error else {
             XCTFail()
             return
@@ -504,7 +627,7 @@ class TAPICreateDataTests: TAPISessionTests {
     }
 
     func testRequestNotAuthorized() {
-        URLProtocolMock.success?.statusCode = 403
+        setUpRequestNotAuthorized()
         guard let error = performRequest(), case .requestNotAuthorized = error else {
             XCTFail()
             return
@@ -515,7 +638,7 @@ class TAPICreateDataTests: TAPISessionTests {
         let errors = [TError.Detail(code: "code-123", title: "title-123", detail: "detail-123"),
                       TError.Detail(code: "code-456", title: "title-456", detail: "detail-456"),
                       TError.Detail(code: "code-789", title: "title-789", detail: "detail-789")]
-        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 400, headers: headers, body: LegacyResponse.Failure(errors: errors))
+        URLProtocolMock.handlers[0].success = URLProtocolMock.Success(statusCode: 400, headers: headers, body: LegacyResponse.Failure(errors: errors))
         guard let error = performRequest(), case .requestMalformedJSON(_, _, let malformedJSONErrors) = error else {
             XCTFail()
             return
@@ -524,7 +647,7 @@ class TAPICreateDataTests: TAPISessionTests {
     }
 
     func testResponseMalformedJSON() {
-        URLProtocolMock.success?.body = nil
+        setUpResponseMalformedJSON()
         guard let error = performRequest(), case .responseMalformedJSON = error else {
             XCTFail()
             return
@@ -538,28 +661,32 @@ class TAPICreateDataTests: TAPISessionTests {
         }
     }
 
+    func testSuccessAfterRefresh() {
+        setUpSessionWantsRefresh()
+        testSuccess()
+    }
+
     private func performRequest() -> TError? {
         let expectation = XCTestExpectationWithError()
-        api.createData(data, dataSetId: dataSetId, session: session) { expectation.fulfill($0) }
+        api.createData(data, dataSetId: dataSetId) { expectation.fulfill($0) }
         XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
         return expectation.error
     }
 }
 
-class TAPIDeleteDataTests: TAPISessionTests {
+class TAPIDeleteDataTests: TAPIRefreshSessionTests {
     let dataSetId = randomString
     let selectors = [TDatum.Selector(id: randomString), TDatum.Selector(origin: TDatum.Selector.Origin(id: randomString))]
 
     override func setUp() {
         super.setUp()
 
-        URLProtocolMock.validator = URLProtocolMock.Validator(url: "https://test.org/v1/data_sets/\(dataSetId)/data", method: "DELETE", headers: headers, body: selectors)
-        URLProtocolMock.error = nil
-        URLProtocolMock.success = URLProtocolMock.Success(statusCode: 200, headers: headers, body: LegacyResponse.Success<DataResponse>(data: DataResponse()))
+        URLProtocolMock.handlers = [URLProtocolMock.Handler(validator: URLProtocolMock.Validator(url: "https://test.org/v1/data_sets/\(dataSetId)/data", method: "DELETE", headers: headers, body: selectors),
+                                                            success: URLProtocolMock.Success(statusCode: 200, headers: headers, body: LegacyResponse.Success<DataResponse>(data: DataResponse())))]
     }
 
     func testNetworkError() {
-        URLProtocolMock.error = TestError()
+        setUpNetworkError()
         guard let error = performRequest(), case .network(let networkError) = error else {
             XCTFail()
             return
@@ -568,7 +695,7 @@ class TAPIDeleteDataTests: TAPISessionTests {
     }
 
     func testRequestNotAuthenticated() {
-        URLProtocolMock.success?.statusCode = 401
+        setUpRequestNotAuthenticated()
         guard let error = performRequest(), case .requestNotAuthenticated = error else {
             XCTFail()
             return
@@ -576,7 +703,7 @@ class TAPIDeleteDataTests: TAPISessionTests {
     }
 
     func testRequestNotAuthorized() {
-        URLProtocolMock.success?.statusCode = 403
+        setUpRequestNotAuthorized()
         guard let error = performRequest(), case .requestNotAuthorized = error else {
             XCTFail()
             return
@@ -590,10 +717,21 @@ class TAPIDeleteDataTests: TAPISessionTests {
         }
     }
 
+    func testSuccessAfterRefresh() {
+        setUpSessionWantsRefresh()
+        testSuccess()
+    }
+
     private func performRequest() -> TError? {
         let expectation = XCTestExpectationWithError()
-        api.deleteData(withSelectors: selectors, dataSetId: dataSetId, session: session) { expectation.fulfill($0) }
+        api.deleteData(withSelectors: selectors, dataSetId: dataSetId) { expectation.fulfill($0) }
         XCTAssertNotEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .timedOut)
         return expectation.error
+    }
+}
+
+fileprivate extension TSession {
+    init(session: TSession, createdDate: Date) {
+        self.init(environment: session.environment, authenticationToken: session.authenticationToken, userId: session.userId, trace: session.trace, createdDate: createdDate)
     }
 }

--- a/TidepoolKitTests/TAPITests.swift
+++ b/TidepoolKitTests/TAPITests.swift
@@ -63,7 +63,6 @@ class TAPIEnvironmentTests: TAPITests {
 class TAPIURLSessionConfigurationTests: TAPITests {
     func testDefaultURLSessionConfiguration() {
         let urlSessionConfiguration = api.urlSessionConfiguration
-        XCTAssertEqual(urlSessionConfiguration.waitsForConnectivity, true)
         XCTAssertNotNil(urlSessionConfiguration.httpAdditionalHeaders)
         XCTAssertNotNil(urlSessionConfiguration.httpAdditionalHeaders?["User-Agent"])
         XCTAssertNotNil(urlSessionConfiguration.protocolClasses)

--- a/TidepoolKitTests/TSessionTests.swift
+++ b/TidepoolKitTests/TSessionTests.swift
@@ -13,12 +13,14 @@ class TSessionTests: XCTestCase {
     static let session = TSession(environment: TEnvironmentTests.environment,
                                   authenticationToken: "test-authentication-token",
                                   userId: "1234567890",
-                                  trace: "test-trace")
+                                  trace: "test-trace",
+                                  createdDate: Date.test)
     static let sessionJSONDictionary: [String: Any] = [
         "environment": TEnvironmentTests.environmentJSONDictionary,
         "authenticationToken": "test-authentication-token",
         "userId": "1234567890",
-        "trace": "test-trace"
+        "trace": "test-trace",
+        "createdDate": Date.testJSONString
     ]
 
     func testInitializer() {
@@ -27,9 +29,19 @@ class TSessionTests: XCTestCase {
         XCTAssertEqual(session.authenticationToken, "test-authentication-token")
         XCTAssertEqual(session.userId, "1234567890")
         XCTAssertEqual(session.trace, "test-trace")
+        XCTAssertEqual(session.createdDate, Date.test)
     }
 
     func testCodableAsJSON() {
         XCTAssertCodableAsJSON(TSessionTests.session, TSessionTests.sessionJSONDictionary)
+    }
+
+    func testInitializerFromExistingSession() {
+        let session = TSession(session: TSessionTests.session, authenticationToken: "refreshed-authentication-token")
+        XCTAssertEqual(session.environment, TEnvironmentTests.environment)
+        XCTAssertEqual(session.authenticationToken, "refreshed-authentication-token")
+        XCTAssertEqual(session.userId, "1234567890")
+        XCTAssertEqual(session.trace, "test-trace")
+        XCTAssertNotEqual(session.createdDate, Date.test)
     }
 }

--- a/TidepoolKitUI/Internal/View Models/LoginSignupViewModel.swift
+++ b/TidepoolKitUI/Internal/View Models/LoginSignupViewModel.swift
@@ -23,13 +23,12 @@ class LoginSignupViewModel: TLoginSignup {
     var resolvedEnvironment: TEnvironment { environment ?? environments.first! }
 
     func login(email: String, password: String, completion: @escaping (Error?) -> Void) {
-        api.login(environment: resolvedEnvironment, email: email, password: password) { result in
-            switch result {
-            case .failure(let error):
+        api.login(environment: resolvedEnvironment, email: email, password: password) { error in
+            if let error = error {
                 completion(error)
-            case .success(let session):
-                self.loginSignupDelegate?.loginSignup(self, didCreateSession: session, completion: completion)
+                return
             }
+            self.loginSignupDelegate?.loginSignupDidComplete(completion: completion)
         }
     }
 

--- a/TidepoolKitUI/TAPI+UI.swift
+++ b/TidepoolKitUI/TAPI+UI.swift
@@ -11,13 +11,11 @@ import TidepoolKit
 /// The delegate for the Tidepool login and signup UI.
 public protocol TLoginSignupDelegate: AnyObject {
 
-    /// Notify the delegate that the login or signup was successful and a session was created.
+    /// Notify the delegate that the login or signup did complete.
     ///
     /// - Parameters:
-    ///   - loginSignup: The login signup that invoked the delegate
-    ///   - session: The newly created session
     ///   - completion: The completion function to invoke with any error.
-    func loginSignup(_ loginSignup: TLoginSignup, didCreateSession session: TSession, completion: @escaping (Error?) -> Void)
+    func loginSignupDidComplete(completion: @escaping (Error?) -> Void)
 
     /// Notify the delegate that the login or signup was cancelled.
     func loginSignupCancelled()


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-1274
- Add Prescription and PrescriptionClaim types
- Add TAPI.claimPrescription endpoint
- Move session maintenance internally within TAPI
- Automatically refresh session after expiration and authentication failures
- Add TAPIObserver to allow monitoring of session updates
- Add TSession created date to determine if automatic refresh is desired
- Add, updated, and refactor tests and mocks