### PR TITLE
LOOP-1114: Enable configuration of the default Tidepool Environment using appGroup

### DIFF
--- a/TidepoolKit.xcodeproj/project.pbxproj
+++ b/TidepoolKit.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1D63DE9E26E8095E00F46FA5 /* TInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D63DE9D26E8095E00F46FA5 /* TInfo.swift */; };
 		1D63DEA026E8209200F46FA5 /* TInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D63DE9F26E8209200F46FA5 /* TInfoTests.swift */; };
+		1D63F486271A456700CC065D /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D63F485271A456700CC065D /* UserDefaults.swift */; };
 		A903670523D939AE009BD8C5 /* TextButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A903670423D939AE009BD8C5 /* TextButtonTableViewCell.swift */; };
 		A9116ACD2405B7F300483021 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116ACC2405B7F300483021 /* Bundle.swift */; };
 		A9116ACF2405CC3300483021 /* LegacyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9116ACE2405CC3300483021 /* LegacyResponse.swift */; };
@@ -243,6 +244,7 @@
 /* Begin PBXFileReference section */
 		1D63DE9D26E8095E00F46FA5 /* TInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TInfo.swift; sourceTree = "<group>"; };
 		1D63DE9F26E8209200F46FA5 /* TInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TInfoTests.swift; sourceTree = "<group>"; };
+		1D63F485271A456700CC065D /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
 		A903670423D939AE009BD8C5 /* TextButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextButtonTableViewCell.swift; sourceTree = "<group>"; };
 		A9116ACC2405B7F300483021 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		A9116ACE2405CC3300483021 /* LegacyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyResponse.swift; sourceTree = "<group>"; };
@@ -767,6 +769,7 @@
 				A994917923FE15CE00865738 /* HTTPURLResponse.swift */,
 				A994917F23FE1AD500865738 /* ProcessInfo.swift */,
 				A9116AD72406012600483021 /* TimeInterval.swift */,
+				1D63F485271A456700CC065D /* UserDefaults.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1152,6 +1155,7 @@
 				A9307631241224C700D1E376 /* TCGMSettingsDatum.swift in Sources */,
 				A930762D241224C700D1E376 /* TBloodKetoneDatum.swift in Sources */,
 				A9307643241224C700D1E376 /* TWaterDatum.swift in Sources */,
+				1D63F486271A456700CC065D /* UserDefaults.swift in Sources */,
 				A973CD2923D68FE000C44032 /* TAPI.swift in Sources */,
 				A9307633241224C700D1E376 /* TReservoirChangeDeviceEventDatum.swift in Sources */,
 				A9E33AA126444DC200B8D280 /* WeakSynchronizedSet.swift in Sources */,

--- a/TidepoolKit/Internal/Extensions/Bundle.swift
+++ b/TidepoolKit/Internal/Extensions/Bundle.swift
@@ -30,5 +30,5 @@ extension Bundle {
 
     var bundleVersion: String? { string(forInfoDictionaryKey: "CFBundleVersion") }
 
-    private func string(forInfoDictionaryKey key: String) -> String? { object(forInfoDictionaryKey: key) as? String }
+    func string(forInfoDictionaryKey key: String) -> String? { object(forInfoDictionaryKey: key) as? String }
 }

--- a/TidepoolKit/Internal/Extensions/UserDefaults.swift
+++ b/TidepoolKit/Internal/Extensions/UserDefaults.swift
@@ -26,7 +26,7 @@ extension UserDefaults {
             return try? JSONDecoder.tidepool.decode(TEnvironment.self, from: data)
         }
         set {
-            set(try! JSONEncoder.tidepool.encode(newValue), forKey: Key.defaultEnvironment.rawValue)
+            set(try? JSONEncoder.tidepool.encode(newValue), forKey: Key.defaultEnvironment.rawValue)
         }
     }
 

--- a/TidepoolKit/Internal/Extensions/UserDefaults.swift
+++ b/TidepoolKit/Internal/Extensions/UserDefaults.swift
@@ -1,0 +1,37 @@
+//
+//  UserDefaults.swift
+//  TidepoolKit
+//
+//  Created by Rick Pasetto on 10/15/21.
+//  Copyright © 2021 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+extension UserDefaults {
+    
+    // This allows TidepoolKit host apps to configure the default Tidepool environment by storing a TEnvironment in a
+    // App Group (denoted by the special key "AppGroupIdentifier" -- see below) under the key "org.tidepool.TidepoolKit.DefaultEnvironment".
+    public static let appGroup = UserDefaults(suiteName: Bundle.main.appGroupSuiteName)
+
+    private enum Key: String {
+        case defaultEnvironment = "org.tidepool.TidepoolKit.DefaultEnvironment"
+    }
+    
+    var defaultEnvironment: TEnvironment? {
+        get {
+            guard let data = data(forKey: Key.defaultEnvironment.rawValue) else {
+                return nil
+            }
+            return try? JSONDecoder.tidepool.decode(TEnvironment.self, from: data)
+        }
+        set {
+            set(try! JSONEncoder.tidepool.encode(newValue), forKey: Key.defaultEnvironment.rawValue)
+        }
+    }
+
+}
+
+extension Bundle {
+    fileprivate var appGroupSuiteName: String? { string(forInfoDictionaryKey: "AppGroupIdentifier") }
+}

--- a/TidepoolKit/TAPI.swift
+++ b/TidepoolKit/TAPI.swift
@@ -25,6 +25,17 @@ public class TAPI {
     /// environments discovered from the latest DNS SRV record lookup. When an instance of TAPI is created it will automatically
     /// perform a DNS SRV record lookup in the background. A client should generally only have one instance of TAPI.
     public var environments: [TEnvironment] { environmentsLocked.value }
+    
+    /// The default environment may come from a configuration from the host app's appGroup.  Otherwise, it defaults to the first environment.
+    /// See also the UserDefaults extension.
+    public var defaultEnvironment: TEnvironment? {
+        get {
+            UserDefaults.appGroup?.defaultEnvironment ?? environments.first
+        }
+        set {
+            UserDefaults.appGroup?.defaultEnvironment = newValue
+        }
+    }
 
     /// The URLSessionConfiguration used for all requests. The default is typically acceptable for most purposes. Any changes
     /// will only apply to subsequent requests.
@@ -215,7 +226,7 @@ public class TAPI {
     ///   - completion: The completion function to invoke with any error.
     public func getInfo(environment: TEnvironment? = nil, completion: @escaping (Result<TInfo, TError>) -> Void) {
         // Note: no session is needed
-        let request = createRequest(environment: environment ?? session?.environment ?? environments.first!, method: "GET", path: "/info")
+        let request = createRequest(environment: environment ?? session?.environment ?? defaultEnvironment!, method: "GET", path: "/info")
         performRequest(request, allowSessionRefresh: false, completion: completion)
     }
 


### PR DESCRIPTION
This makes it possible to build TidepoolKit in multiple apps within an appGroup (denoted by the special Info.plist key, "AppGroupIdentifier"), and have one app configure the default TEnvironment TAPI uses.
