### PR TITLE
Adds API endpoint to resend a caregiver invitation.

### DIFF
--- a/Sources/TidepoolKit/TAPI.swift
+++ b/Sources/TidepoolKit/TAPI.swift
@@ -383,6 +383,20 @@ public actor TAPI {
         return try await performRequest(request)
     }
     
+    /// Resend invite to follow the user account specified by the ``creatorId`` of the original ``TInvite`` structure.
+    ///
+    /// - Parameters:
+    ///   - key: The unique identification key of the original ``TInvite`` structure.
+    /// - Returns: A confirmation/response
+    public func resendInvite(key: String) async throws -> String {
+        guard session != nil else {
+            throw TError.sessionMissing
+        }
+
+        let request = try createRequest(method: "PATCH", path: "/confirm/resend/invite/\(key)")
+        return try await performRequest(request)
+    }
+    
     /// Accept a pending invite sent to the user account identified by userId. If no user id is specified, then the session user id is used.
     ///
     /// - Parameters:


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/CPA-91

https://www.figma.com/file/Gzg4B3Skhme9R82gDNyH5a/Care-Partner-Explorations?type=design&node-id=2568-44262&mode=design&t=mFMooZ3WUZbBMaY8-0

**Adds endpoint to resend a `pending` invite to caregiver.** 
**Note**: API only supports resending invitations with `pending` status. `Declined` status can only be canceled.