### PR TITLE
[LOOP-5065] updated device logs API to allow for null response

### DIFF
--- a/Sources/TidepoolKit/Model/TDeviceLogsMetadata.swift
+++ b/Sources/TidepoolKit/Model/TDeviceLogsMetadata.swift
@@ -17,6 +17,6 @@ public struct TDeviceLogsMetadata: Codable, Equatable {
     public var mediaType: String
     public var size: Int
     public var createdTime: Date
-    public var startAtTime: Date
-    public var endAtTime: Date
+    public var startAt: Date
+    public var endAt: Date
 }

--- a/Sources/TidepoolKit/Model/TDeviceLogsMetadata.swift
+++ b/Sources/TidepoolKit/Model/TDeviceLogsMetadata.swift
@@ -17,6 +17,6 @@ public struct TDeviceLogsMetadata: Codable, Equatable {
     public var mediaType: String
     public var size: Int
     public var createdTime: Date
-    public var startAt: Date
-    public var endAt: Date
+    public var startAtTime: Date
+    public var endAtTime: Date
 }

--- a/Sources/TidepoolKit/TAPI.swift
+++ b/Sources/TidepoolKit/TAPI.swift
@@ -766,8 +766,8 @@ public actor TAPI {
     /// - Parameters:
     ///   - start: the start date of the period that contains the log entries
     ///   - end: the end date of the period that contains the log entries
-    /// - Returns: A list of ``TDeviceLogsMetadata`` structures
-    public func listDeviceLogs(start: Date, end: Date) async throws -> [TDeviceLogsMetadata] {
+    /// - Returns: An optional list of ``TDeviceLogsMetadata`` structures. If the list is empty, `nil` is returned
+    public func listDeviceLogs(start: Date, end: Date) async throws -> [TDeviceLogsMetadata]? {
         guard let session = session else {
             throw TError.sessionMissing
         }

--- a/Sources/TidepoolKit/TAPI.swift
+++ b/Sources/TidepoolKit/TAPI.swift
@@ -766,8 +766,8 @@ public actor TAPI {
     /// - Parameters:
     ///   - start: the start date of the period that contains the log entries
     ///   - end: the end date of the period that contains the log entries
-    /// - Returns: An optional list of ``TDeviceLogsMetadata`` structures. If the list is empty, `nil` is returned
-    public func listDeviceLogs(start: Date, end: Date) async throws -> [TDeviceLogsMetadata]? {
+    /// - Returns: A list of ``TDeviceLogsMetadata`` structures
+    public func listDeviceLogs(start: Date, end: Date) async throws -> [TDeviceLogsMetadata] {
         guard let session = session else {
             throw TError.sessionMissing
         }
@@ -780,7 +780,9 @@ public actor TAPI {
                 URLQueryItem(name: "endAtTime", value: end.timeString)
             ]
         )
-        return try await performRequest(request)
+        
+        let deviceLogsMetadata: [TDeviceLogsMetadata]? = try await performRequest(request)
+        return deviceLogsMetadata ?? []
     }
 
 


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-5065