### PR TITLE
[COASTAL-1461] Completion handler called twice with delay

### DIFF
--- a/Sources/TidepoolKit/Auth/OAuth2Authenticator.swift
+++ b/Sources/TidepoolKit/Auth/OAuth2Authenticator.swift
@@ -18,6 +18,7 @@ public class ASWebAuthenticationSessionProvider: OAuth2AuthenticatorSessionProvi
 
     private let contextProviding: ASWebAuthenticationPresentationContextProviding
     private var authenticationSession: ASWebAuthenticationSession?
+    private var previouslyCompleted = false
 
     public init(contextProviding: ASWebAuthenticationPresentationContextProviding) {
         self.contextProviding = contextProviding
@@ -26,6 +27,9 @@ public class ASWebAuthenticationSessionProvider: OAuth2AuthenticatorSessionProvi
     public func startSession(authURL: URL, callbackScheme: String?) async throws -> URL {
         try await withCheckedThrowingContinuation { continuation in
             self.authenticationSession = ASWebAuthenticationSession(url: authURL, callbackURLScheme: callbackScheme) { callbackURL, error in
+                guard !self.previouslyCompleted else { return }
+                self.previouslyCompleted = true
+
                 if let error {
                     continuation.resume(throwing: error)
                     return

--- a/TidepoolKit.xcodeproj/project.pbxproj
+++ b/TidepoolKit.xcodeproj/project.pbxproj
@@ -363,8 +363,8 @@
 		OBJ_94 /* TError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TError.swift; sourceTree = "<group>"; };
 		OBJ_95 /* TLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLogging.swift; sourceTree = "<group>"; };
 		OBJ_96 /* TSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TSession.swift; sourceTree = "<group>"; };
-		"tidepoolkit::TidepoolKit::Product" /* TidepoolKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = TidepoolKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"tidepoolkit::TidepoolKitTests::Product" /* TidepoolKitTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = TidepoolKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"tidepoolkit::TidepoolKit::Product" /* TidepoolKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = TidepoolKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"tidepoolkit::TidepoolKitTests::Product" /* TidepoolKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = TidepoolKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1269,6 +1269,7 @@
 		OBJ_3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1304,6 +1305,7 @@
 		OBJ_4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/COASTAL-1461

Unfortunately, I'm not certain why the `ASWebAuthenticationSession` completion handler is being called twice. It seems to only occur when there is a network delay. The callback URL for the second call is as described in crashlytics:

```
... tried to resume its continuation more than once returning org.tidepool.tidepoolkit.auth://redirect?
error=temporarily_unavailable&error_description=authentication_expired&iss=https%3A%2F%2Fauth.qa2.tidepool.org
%2Frealms%2Fqa1!
```

This stops the crash, but obviously does not fix the root issue.