### PR TITLE
Add podspec file (MOBILE-683)

### DIFF
--- a/TidepoolKit.podspec
+++ b/TidepoolKit.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |spec|
+  spec.name         = "TidepoolKit"
+  spec.version      = "1.0.0"
+  spec.summary      = "An iOS framework for communicating with the Tidepool platform."
+  spec.description  = <<-DESC
+    TidepoolKit provides OAuth2/OIDC authentication and a full API client
+    for the Tidepool diabetes data platform.
+  DESC
+
+  spec.homepage     = "https://github.com/tidepool-org/TidepoolKit"
+  spec.license      = { :type => "BSD-2-Clause", :file => "LICENSE" }
+  spec.author       = { "Tidepool" => "support@tidepool.org" }
+  spec.platform     = :ios, "15.1"
+  spec.source       = { :git => "https://github.com/tidepool-org/TidepoolKit.git", :branch => "dev" }
+  spec.source_files = "Sources/TidepoolKit/**/*.swift"
+  spec.swift_version = "5.7"
+end


### PR DESCRIPTION
We're rebooting Tidepool Mobile as [mobile-remix](github.com/tidepool-org/mobile-remix), and since [healthkit-uploader](https://github.com/tidepool-org/healthkit-uploader) is a CocoaPod it requires TidepoolKit to be a CocoaPod too - can we add this podspec file to do this?

Addresses [MOBILE-683](https://tidepool.atlassian.net/browse/MOBILE-683).